### PR TITLE
multipart data support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The camera_aravis driver has long history of multiple forks and now abandoned Gi
 
 ------------------------
 
-Tested with Aravis version 0.8.X. Since it has changed the API, specially the error handling.
+Tested with Aravis version 0.8.25, requires >= 0.8.23 for multipart data handling.
 
 The basic command to run camera_aravis:
 
@@ -80,6 +80,16 @@ To specify which camera to open, via a parameter:
 	$ rosparam set /camera_aravis/guid Basler-21237813
 	$ rosrun camera_aravis cam_aravis
 
+-------------------------
+
+camera_aravis supports multisource cameras and multipart data
+
+use `channel_name`, `pixel_format` and `camera_info_url` to specify multisource/multipart camera
+- `;` seperates multi-source channels
+- `,` separates multipart parts
+- even if you don't specify `camera_info_urls` keep the correct structure, e.g. `","`
+- for example multisource see `multisource_camera_aravis.launch`
+- for example multipart see `photoneo_motioncam.launch`
 
 ------------------------
 It supports the dynamic_reconfigure protocol, and once the node is running, you may adjust

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -133,7 +133,7 @@ protected:
   static void newBufferReadyCallback(ArvStream *p_stream, gpointer can_instance);
 
   // Buffer Callback Helper
-  static void newBufferReady(ArvStream *p_stream, CameraAravisNodelet *p_can, std::string frame_id, size_t stream_id);
+  void newBufferReady(ArvStream *p_stream, std::string frame_id, size_t stream_id);
 
   // Clean-up if aravis device is lost
   static void controlLostCallback(ArvDevice *p_gv_device, gpointer can_instance);

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -184,6 +184,7 @@ protected:
   void processImageBuffer(ArvBuffer *p_buffer, size_t stream_id);
   void processChunkDataBuffer(ArvBuffer *p_buffer, size_t stream_id);
   void processMultipartBuffer(ArvBuffer *p_buffer, size_t stream_id);
+  void processPartBuffer(ArvBuffer *p_buffer, size_t stream_id, size_t substream_id, const void* data, size_t size);
 
   // Clean-up if aravis device is lost
   static void controlLostCallback(ArvDevice *p_gv_device, gpointer can_instance);

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -186,6 +186,10 @@ protected:
   void processMultipartBuffer(ArvBuffer *p_buffer, size_t stream_id);
   void processPartBuffer(ArvBuffer *p_buffer, size_t stream_id, size_t substream_id, const void* data, size_t size);
 
+  void fillImage(const sensor_msgs::ImagePtr &msg_ptr, ArvBuffer *p_buffer, const std::string frame_id, const Sensor& sensor);
+  void fillCameraInfo(Substream &substream, const std_msgs::Header &header);
+  void publishExtendedCameraInfo(const Substream &substream,  size_t stream_id);
+
   // Clean-up if aravis device is lost
   static void controlLostCallback(ArvDevice *p_gv_device, gpointer can_instance);
 

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -135,6 +135,9 @@ protected:
   // Buffer Callback Helper
   void newBufferReady(ArvStream *p_stream, size_t stream_id);
 
+  // Process Validated Buffer
+  void processBuffer(ArvBuffer *p_buffer, size_t stream_id);
+
   // Clean-up if aravis device is lost
   static void controlLostCallback(ArvDevice *p_gv_device, gpointer can_instance);
 

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -138,6 +138,10 @@ protected:
   // Process Validated Buffer
   void processBuffer(ArvBuffer *p_buffer, size_t stream_id);
 
+  void processImageBuffer(ArvBuffer *p_buffer, size_t stream_id);
+  void processChunkDataBuffer(ArvBuffer *p_buffer, size_t stream_id);
+  void processMultipartBuffer(ArvBuffer *p_buffer, size_t stream_id);
+
   // Clean-up if aravis device is lost
   static void controlLostCallback(ArvDevice *p_gv_device, gpointer can_instance);
 

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -106,11 +106,12 @@ private:
     size_t n_bits_pixel = 0;
   };
 /*
-  // for multipart/chunked data
-  struct Part
+  // logically single kind of data (image/image chunk/image in multipart/depth map/...)
+  // a single stream may transfer multiple substreams (multipart/chunked data)
+  struct Substream
   {
     Sensor sensor;
-    std::string part_name;
+    std::string substream_name;
     ConversionFunction convert_format;
 
     image_transport::CameraPublisher cam_pub;
@@ -124,7 +125,7 @@ private:
   {
     Sensor sensor;
     ArvStream *p_stream;
-    std::string stream_name;
+    std::string name;
     CameraBufferPool::Ptr p_buffer_pool;
     ConversionFunction convert_format;
 

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -120,7 +120,7 @@ private:
     ros::Publisher extended_camera_info_pub;
   };
 */
-  struct Source
+  struct Stream
   {
     Sensor sensor;
     ArvStream *p_stream;
@@ -135,7 +135,7 @@ private:
     ros::Publisher extended_camera_info_pub;
   };
 
-  std::vector<Source> sources_;
+  std::vector<Stream> streams_;
 
   int32_t acquire_ = 0;
 

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -96,8 +96,6 @@ private:
   ArvCamera *p_camera_ = NULL;
   ArvDevice *p_device_ = NULL;
 
-  gint num_streams_ = 0;
-
   struct Sensor
   {
     int32_t width = 0;
@@ -139,7 +137,7 @@ private:
 
   virtual void onInit() override;
   void connectToCamera();
-  void discoverStreams(size_t stream_names_size);
+  int discoverStreams(size_t stream_names_size);
   void initPixelFormats();
   void getBounds();
   void setUSBMode();

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -138,7 +138,7 @@ private:
   virtual void onInit() override;
   void connectToCamera();
   void discoverStreams(size_t stream_names_size);
-  std::vector<ConversionFunction> initPixelFormats();
+  void initPixelFormats();
   void getBounds();
   void setUSBMode();
   void setCameraSettings();
@@ -161,7 +161,7 @@ protected:
   void setAutoMaster(bool value);
   void setAutoSlave(bool value);
 
-  void setExtendedCameraInfo(std::string channel_name, size_t stream_id);
+  void setExtendedCameraInfo(std::string channel_name, size_t stream_id, size_t substream_id);
   void fillExtendedCameraInfoMessage(ExtendedCameraInfo &msg);
 
   // Extra stream options for GigEVision streams.

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -212,7 +212,6 @@ protected:
 
   std::thread software_trigger_thread_;
   std::atomic_bool software_trigger_active_;
-  size_t n_buffers_ = 0;
 
   std::unordered_map<std::string, const bool> implemented_features_;
 

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -111,6 +111,8 @@ private:
   {
     Sensor sensor;
     std::string name;
+    //pool for multipart path where images don't map 1:1 to aravis buffers
+    CameraBufferPool::Ptr p_buffer_pool;
     ConversionFunction convert_format;
 
     image_transport::CameraPublisher cam_pub;

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -133,7 +133,7 @@ protected:
   static void newBufferReadyCallback(ArvStream *p_stream, gpointer can_instance);
 
   // Buffer Callback Helper
-  void newBufferReady(ArvStream *p_stream, std::string frame_id, size_t stream_id);
+  void newBufferReady(ArvStream *p_stream, size_t stream_id);
 
   // Clean-up if aravis device is lost
   static void controlLostCallback(ArvDevice *p_gv_device, gpointer can_instance);

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -105,13 +105,12 @@ private:
     std::string pixel_format;
     size_t n_bits_pixel = 0;
   };
-/*
+
   // logically single kind of data (image/image chunk/image in multipart/depth map/...)
-  // a single stream may transfer multiple substreams (multipart/chunked data)
   struct Substream
   {
     Sensor sensor;
-    std::string substream_name;
+    std::string name;
     ConversionFunction convert_format;
 
     image_transport::CameraPublisher cam_pub;
@@ -120,20 +119,17 @@ private:
     sensor_msgs::CameraInfoPtr camera_info;
     ros::Publisher extended_camera_info_pub;
   };
-*/
+
+  // a single stream may transfer multiple substreams (multipart/chunked data)
   struct Stream
   {
-    Sensor sensor;
     ArvStream *p_stream;
     std::string name;
     CameraBufferPool::Ptr p_buffer_pool;
-    ConversionFunction convert_format;
 
-    image_transport::CameraPublisher cam_pub;
-    std::unique_ptr<camera_info_manager::CameraInfoManager> p_camera_info_manager;
-    std::unique_ptr<ros::NodeHandle> p_camera_info_node_handle;
-    sensor_msgs::CameraInfoPtr camera_info;
-    ros::Publisher extended_camera_info_pub;
+    // typical image-like data or multipart/chunk with image-like data
+    // each stream has at least 1 substream
+    std::vector<Substream> substreams;
   };
 
   std::vector<Stream> streams_;

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -220,7 +220,8 @@ protected:
 
   void discoverFeatures();
 
-  static void parseStringArgs(std::string in_arg_string, std::vector<std::string> &out_args);
+  static void parseStringArgs(std::string in_arg_string, std::vector<std::string> &out_args, char seprator = ';');
+  void parseStringArgs2D(std::string in_arg_string, std::vector<std::vector<std::string>> &out_args) const;
 
   // WriteCameraFeaturesFromRosparam()
   // Read ROS parameters from this node's namespace, and see if each parameter has a similarly named & typed feature in the camera.  Then set the

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -124,7 +124,6 @@ private:
   struct Stream
   {
     ArvStream *p_stream;
-    std::string name;
     CameraBufferPool::Ptr p_buffer_pool;
 
     // typical image-like data or multipart/chunk with image-like data

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -222,7 +222,7 @@ protected:
   void discoverFeatures();
 
   static void parseStringArgs(std::string in_arg_string, std::vector<std::string> &out_args, char seprator = ';');
-  void parseStringArgs2D(std::string in_arg_string, std::vector<std::vector<std::string>> &out_args) const;
+  static void parseStringArgs2D(std::string in_arg_string, std::vector<std::vector<std::string>> &out_args);
 
   // WriteCameraFeaturesFromRosparam()
   // Read ROS parameters from this node's namespace, and see if each parameter has a similarly named & typed feature in the camera.  Then set the

--- a/include/camera_aravis/conversion_utils.h
+++ b/include/camera_aravis/conversion_utils.h
@@ -93,6 +93,7 @@ const std::map<std::string, ConversionFunction> CONVERSIONS_DICTIONARY =
  { "Data32s", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::TYPE_32SC1) },
  { "Data32f", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::TYPE_32FC1) },
  { "Confidence32f", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::TYPE_32FC1) },
+ { "Coord3D_C32f", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::TYPE_32FC1) },
  { "Data64f", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::TYPE_64FC1) },
  // unthrifty formats. Shift away padding Bits for use with ROS.
  { "Mono10", std::bind(&shiftImg, std::placeholders::_1, std::placeholders::_2, 6, sensor_msgs::image_encodings::MONO16) },

--- a/launch/camera_aravis.launch
+++ b/launch/camera_aravis.launch
@@ -33,8 +33,9 @@
       <param name="publish_tf"           value="true"/>
       <param name="tf_publish_rate"      value="$(arg fps)"/>
 
+      <param name="pixel_format"          value="$(arg pixel_format)"/>
+
       <!-- use GenICam SFNC names as stream control parameters -->
-      <param name="PixelFormat"          value="$(arg pixel_format)"/>
       <param name="Width"                value="$(arg width)"/>
       <param name="Height"               value="$(arg height)"/>
       <param name="AcquisitionFrameRate" type="double" value="$(arg fps)"/>

--- a/launch/multisource_camera_aravis.launch
+++ b/launch/multisource_camera_aravis.launch
@@ -35,9 +35,9 @@
 
       <param name="publish_tf"           value="true"/>
       <param name="tf_publish_rate"      value="$(arg fps)"/>
+      <param name="pixel_format"          value="$(arg pixel_format)"/>
 
       <!-- use GenICam SFNC names as stream control parameters -->
-      <param name="PixelFormat"          value="$(arg pixel_format)"/>
       <param name="Width"                value="$(arg width)"/>
       <param name="Height"               value="$(arg height)"/>
       <param name="AcquisitionFrameRate" type="double" value="$(arg fps)"/>

--- a/launch/multisource_camera_aravis.launch
+++ b/launch/multisource_camera_aravis.launch
@@ -7,10 +7,10 @@
 
   <arg name="sensor_name"              default="aravis_cam"/>
   <arg name="serial_no"                default=""/>
-  <arg name="camera_info_url"          default="file://$(find camera_aravis)/launch/calib_vis.yaml,file://$(find camera_aravis)/launch/calib_nir.yaml"/>
+  <arg name="camera_info_url"          default="file://$(find camera_aravis)/launch/calib_vis.yaml;file://$(find camera_aravis)/launch/calib_nir.yaml"/>
 
-  <arg name="channel_names"            default="vis,nir"/>
-  <arg name="pixel_format"             default="BayerRG8,Mono8"/>
+  <arg name="channel_names"            default="vis;nir"/>
+  <arg name="pixel_format"             default="BayerRG8;Mono8"/>
   <arg name="width"                    default="2048"/>
   <arg name="height"                   default="1536"/>
   <arg name="fps"                      default="10"/>
@@ -52,19 +52,19 @@
     </node>
 
     <!-- Debayer & Undistort both images -->
-    <node ns="$(eval arg('channel_names').split(',')[0])" pkg="nodelet" type="nodelet" name="debayer"
+    <node ns="$(eval arg('channel_names').split(';')[0])" pkg="nodelet" type="nodelet" name="debayer"
           args="load image_proc/debayer $(arg manager)">
       <param name="debayer" value="0"/>
     </node>
 
-    <node ns="$(eval arg('channel_names').split(',')[0])" pkg="nodelet" type="nodelet" name="rectify_color"
+    <node ns="$(eval arg('channel_names').split(';')[0])" pkg="nodelet" type="nodelet" name="rectify_color"
           args="load image_proc/rectify $(arg manager)">
       <param name="interpolation" value="1"/>
       <remap from="image_mono" to="image_color"/>
       <remap from="image_rect" to="image_rect_color"/>
     </node>
 
-    <node ns="$(eval arg('channel_names').split(',')[1])" pkg="nodelet" type="nodelet" name="rectify_mono"
+    <node ns="$(eval arg('channel_names').split(';')[1])" pkg="nodelet" type="nodelet" name="rectify_mono"
           args="load image_proc/rectify $(arg manager)">
       <param name="interpolation" value="1"/>
       <remap from="image_mono" to="image_raw"/>

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="load_manager"             default="true"/>
+  <arg name="manager_name"             default="camera_manager"/>
+  <arg name="manager"                  value="/$(arg manager_name)"/>
+  <arg name="manager_threads"          default="4"/>
+
+  <arg name="sensor_name"              default="aravis_camera"/>
+  <arg name="serial_no"                default=""/>
+  <arg name="camera_info_url"          default=""/>
+
+  <arg name="pixel_format"             default="Mono16"/>
+  <arg name="width"                    default="1120"/>
+  <arg name="height"                   default="800"/>
+  <arg name="fps"                      default="20"/>
+
+  <arg name="verbose"                  default="false"/>
+
+  <!-- Nodelet Manager -->
+  <node if="$(arg load_manager)" pkg="nodelet" type="nodelet" name="$(arg manager_name)" args="manager" output="screen">
+    <param name="num_worker_threads" value="$(arg manager_threads)" />
+  </node>
+
+  <group ns="$(arg sensor_name)">
+
+    <!-- Aravis RGB camera nodelet -->
+    <node pkg="nodelet" type="nodelet" name="$(arg sensor_name)" args="standalone camera_aravis/CameraAravisNodelet" output="screen">
+
+      <param name="guid"                 value="$(arg serial_no)"/>
+      <param name="camera_info_url"      value="$(arg camera_info_url)"/>
+      <param name="frame_id"             value="$(arg sensor_name)"/>
+
+      <param name="publish_tf"           value="true"/>
+      <param name="tf_publish_rate"      value="$(arg fps)"/>
+
+      <!-- use GenICam SFNC names as stream control parameters -->
+      <param name="PixelFormat"          value="$(arg pixel_format)"/>
+      <param name="Width"                value="$(arg width)"/>
+      <param name="Height"               value="$(arg height)"/>
+      <param name="AcquisitionFrameRate" type="double" value="$(arg fps)"/>
+
+      <param name="Gamma"                value="0.41"/>
+      <param name="Gain"                 value="0.0"/>
+      <param name="AutoFunctionsROIPreset" value="AutoFunctionsROIPreset_Full"/>
+      <param name="ExposureAuto"         value="Continuous"/>
+      <param name="GainAuto"             value="Continuous"/>
+      <param name="BalanceWhiteAuto"     value="Continuous"/>
+
+    </node>
+
+  </group>
+
+</launch>

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -51,7 +51,7 @@
       <param name="ExposureAuto"         value="Continuous"/>
       <param name="GainAuto"             value="Continuous"/>
       <param name="BalanceWhiteAuto"     value="Continuous"/>
-
+      <param name="OutputTopology"       value="RegularGrid"/>
     </node>
 
   </group>

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -25,6 +25,7 @@
 
     <!-- Aravis RGB camera nodelet -->
     <node pkg="nodelet" type="nodelet" name="$(arg sensor_name)" args="standalone camera_aravis/CameraAravisNodelet" output="screen">
+      <param name="verbose"              value="$(arg verbose)"/>
 
       <param name="guid"                 value="$(arg serial_no)"/>
       <param name="camera_info_url"      value="$(arg camera_info_url)"/>

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -38,9 +38,9 @@
 
       <param name="publish_tf"           value="true"/>
       <param name="tf_publish_rate"      value="$(arg fps)"/>
+      <param name="pixel_format"          value="$(arg pixel_format)"/>
 
       <!-- use GenICam SFNC names as stream control parameters -->
-      <param name="PixelFormat"          value="$(arg pixel_format)"/>
       <param name="Width"                value="$(arg width)"/>
       <param name="Height"               value="$(arg height)"/>
       <param name="AcquisitionFrameRate" type="double" value="$(arg fps)"/>

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -7,7 +7,7 @@
 
   <arg name="sensor_name"              default="aravis_camera"/>
   <arg name="serial_no"                default=""/>
-  <arg name="camera_info_url"          default=""/>
+  <arg name="camera_info_url"          default=","/>
 
   <arg name="channel_names"            default="Intensity,Range"/>
   <arg name="pixel_format"             default="Mono16,Coord3D_C32f"/>

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -16,44 +16,40 @@
   <arg name="height"                   default="800"/>
   <arg name="fps"                      default="20"/>
 
-  <arg name="verbose"                  default="true"/>
+  <arg name="verbose"                  default="false"/>
 
   <!-- Nodelet Manager -->
   <node if="$(arg load_manager)" pkg="nodelet" type="nodelet" name="$(arg manager_name)" args="manager" output="screen">
     <param name="num_worker_threads" value="$(arg manager_threads)" />
   </node>
 
-  <group ns="$(arg sensor_name)">
+  <!-- Aravis RGB camera nodelet -->
+  <node pkg="nodelet" type="nodelet" name="$(arg sensor_name)" args="standalone camera_aravis/CameraAravisNodelet" output="screen">
+    <param name="verbose"              value="$(arg verbose)"/>
 
-    <!-- Aravis RGB camera nodelet -->
-    <node pkg="nodelet" type="nodelet" name="$(arg sensor_name)" args="standalone camera_aravis/CameraAravisNodelet" output="screen">
-      <param name="verbose"              value="$(arg verbose)"/>
+    <param name="guid"                 value="$(arg serial_no)"/>
+    <param name="camera_info_url"      value="$(arg camera_info_url)"/>
+    <param name="frame_id"             value="$(arg sensor_name)"/>
 
-      <param name="guid"                 value="$(arg serial_no)"/>
-      <param name="camera_info_url"      value="$(arg camera_info_url)"/>
-      <param name="frame_id"             value="$(arg sensor_name)"/>
+    <!-- Multistream Camera (not Multisource) -->
+    <param name="channel_names"        value="$(arg channel_names)"/>
 
-      <!-- Multistream Camera (not Multisource) -->
-      <param name="channel_names"        value="$(arg channel_names)"/>
+    <param name="publish_tf"           value="true"/>
+    <param name="tf_publish_rate"      value="$(arg fps)"/>
+    <param name="pixel_format"          value="$(arg pixel_format)"/>
 
-      <param name="publish_tf"           value="true"/>
-      <param name="tf_publish_rate"      value="$(arg fps)"/>
-      <param name="pixel_format"          value="$(arg pixel_format)"/>
+    <!-- use GenICam SFNC names as stream control parameters -->
+    <param name="Width"                value="$(arg width)"/>
+    <param name="Height"               value="$(arg height)"/>
+    <param name="AcquisitionFrameRate" type="double" value="$(arg fps)"/>
 
-      <!-- use GenICam SFNC names as stream control parameters -->
-      <param name="Width"                value="$(arg width)"/>
-      <param name="Height"               value="$(arg height)"/>
-      <param name="AcquisitionFrameRate" type="double" value="$(arg fps)"/>
-
-      <param name="Gamma"                value="0.41"/>
-      <param name="Gain"                 value="0.0"/>
-      <param name="AutoFunctionsROIPreset" value="AutoFunctionsROIPreset_Full"/>
-      <param name="ExposureAuto"         value="Continuous"/>
-      <param name="GainAuto"             value="Continuous"/>
-      <param name="BalanceWhiteAuto"     value="Continuous"/>
-      <param name="OutputTopology"       value="RegularGrid"/>
-    </node>
-
-  </group>
+    <param name="Gamma"                value="0.41"/>
+    <param name="Gain"                 value="0.0"/>
+    <param name="AutoFunctionsROIPreset" value="AutoFunctionsROIPreset_Full"/>
+    <param name="ExposureAuto"         value="Continuous"/>
+    <param name="GainAuto"             value="Continuous"/>
+    <param name="BalanceWhiteAuto"     value="Continuous"/>
+    <param name="OutputTopology"       value="RegularGrid"/>
+  </node>
 
 </launch>

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -9,12 +9,14 @@
   <arg name="serial_no"                default=""/>
   <arg name="camera_info_url"          default=""/>
 
-  <arg name="pixel_format"             default="Mono16"/>
+  <arg name="channel_names"            default="Intensity,Range"/>
+  <arg name="pixel_format"             default="Mono16,Coord3D_C32f"/>
+
   <arg name="width"                    default="1120"/>
   <arg name="height"                   default="800"/>
   <arg name="fps"                      default="20"/>
 
-  <arg name="verbose"                  default="false"/>
+  <arg name="verbose"                  default="true"/>
 
   <!-- Nodelet Manager -->
   <node if="$(arg load_manager)" pkg="nodelet" type="nodelet" name="$(arg manager_name)" args="manager" output="screen">
@@ -30,6 +32,9 @@
       <param name="guid"                 value="$(arg serial_no)"/>
       <param name="camera_info_url"      value="$(arg camera_info_url)"/>
       <param name="frame_id"             value="$(arg sensor_name)"/>
+
+      <!-- Multistream Camera (not Multisource) -->
+      <param name="channel_names"        value="$(arg channel_names)"/>
 
       <param name="publish_tf"           value="true"/>
       <param name="tf_publish_rate"      value="$(arg fps)"/>

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1973,7 +1973,7 @@ void CameraAravisNodelet::parseStringArgs(std::string in_arg_string, std::vector
         std::stringstream ss(in_arg_string.substr(array_start, array_end - array_start));
         while (ss.good()) {
           std::string temp;
-          getline( ss, temp, ',');
+          getline( ss, temp, ';');
           boost::trim_left(temp);
           boost::trim_right(temp);
           out_args.push_back(temp);

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1494,17 +1494,12 @@ void CameraAravisNodelet::rosConnectCallback()
 
 void CameraAravisNodelet::newBufferReadyCallback(ArvStream *p_stream, gpointer can_instance)
 {
-
   // workaround to get access to the instance from a static method
   StreamIdData *data = (StreamIdData*) can_instance;
   CameraAravisNodelet *p_can = (CameraAravisNodelet*) data->can;
   size_t stream_id = data->stream_id;
-  image_transport::CameraPublisher *p_cam_pub = &p_can->cam_pubs_[stream_id];
 
-  const std::string &frame_id = p_can->stream_names_[stream_id].empty() ? p_can->config_.frame_id :
-                                p_can->config_.frame_id + "/" + p_can->stream_names_[stream_id];
-
-  p_can->newBufferReady(p_stream, frame_id, stream_id);
+  p_can->newBufferReady(p_stream, stream_id);
 
   // publish current lighting settings if this camera is configured as master
   if (p_can->config_.AutoMaster)
@@ -1514,7 +1509,7 @@ void CameraAravisNodelet::newBufferReadyCallback(ArvStream *p_stream, gpointer c
   }
 }
 
-void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, std::string frame_id, size_t stream_id)
+void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, size_t stream_id)
 {
   ArvBuffer *p_buffer = arv_stream_try_pop_buffer(p_stream);
 
@@ -1531,6 +1526,9 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, std::string frame_
   bool buffer_success = arv_buffer_get_status(p_buffer) == ARV_BUFFER_STATUS_SUCCESS;
   bool buffer_pool = (bool)p_buffer_pools_[stream_id];
   bool has_subscribers = cam_pubs_[stream_id].getNumSubscribers();
+
+  const std::string &frame_id = stream_names_[stream_id].empty() ? config_.frame_id :
+                                config_.frame_id + "/" + stream_names_[stream_id];
 
   if (!buffer_success)
     ROS_WARN("(%s) Frame error: %s", frame_id.c_str(), szBufferStatusFromInt[arv_buffer_get_status(p_buffer)]);

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1521,6 +1521,7 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, CameraAravisNodele
   // check if we risk to drop the next image because of not enough buffers left
   gint n_available_buffers;
   arv_stream_get_n_buffers(p_stream, &n_available_buffers, NULL);
+
   if (n_available_buffers == 0)
   {
     p_can->p_buffer_pools_[stream_id]->allocateBuffers(1);
@@ -1529,80 +1530,84 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, CameraAravisNodele
   if(p_buffer == nullptr)
     return;
 
-  if (arv_buffer_get_status(p_buffer) == ARV_BUFFER_STATUS_SUCCESS && p_can->p_buffer_pools_[stream_id]
-      && p_can->cam_pubs_[stream_id].getNumSubscribers())
+  bool buffer_success = arv_buffer_get_status(p_buffer) == ARV_BUFFER_STATUS_SUCCESS;
+  bool buffer_pool = (bool)p_can->p_buffer_pools_[stream_id];
+  bool has_subscribers = p_can->cam_pubs_[stream_id].getNumSubscribers();
+
+  if (!buffer_success)
+    ROS_WARN("(%s) Frame error: %s", frame_id.c_str(), szBufferStatusFromInt[arv_buffer_get_status(p_buffer)]);
+
+  if(!buffer_success || !buffer_pool || !has_subscribers)
   {
-    (p_can->n_buffers_)++;
-    // get the image message which wraps around this buffer
-    sensor_msgs::ImagePtr msg_ptr = (*(p_can->p_buffer_pools_[stream_id]))[p_buffer];
-    // fill the meta information of image message
-    // get acquisition time
-    guint64 t;
-    if (p_can->use_ptp_stamp_)
-      t = arv_buffer_get_timestamp(p_buffer);
-    else
-      t = arv_buffer_get_system_timestamp(p_buffer);
-    msg_ptr->header.stamp.fromNSec(t);
-    // get frame sequence number
-    msg_ptr->header.seq = arv_buffer_get_frame_id(p_buffer);
-    // fill other stream properties
-    msg_ptr->header.frame_id = frame_id;
-    msg_ptr->width = p_can->roi_.width;
-    msg_ptr->height = p_can->roi_.height;
-    msg_ptr->encoding = p_can->sensors_[stream_id]->pixel_format;
-    msg_ptr->step = (msg_ptr->width * p_can->sensors_[stream_id]->n_bits_pixel)/8;
-
-    // do the magic of conversion into a ROS format
-    if (p_can->convert_formats[stream_id]) {
-      sensor_msgs::ImagePtr cvt_msg_ptr = p_can->p_buffer_pools_[stream_id]->getRecyclableImg();
-      p_can->convert_formats[stream_id](msg_ptr, cvt_msg_ptr);
-      msg_ptr = cvt_msg_ptr;
-    }
-
-    // get current CameraInfo data
-    if (!p_can->camera_infos_[stream_id]) {
-      p_can->camera_infos_[stream_id].reset(new sensor_msgs::CameraInfo);
-    }
-    (*p_can->camera_infos_[stream_id]) = p_can->p_camera_info_managers_[stream_id]->getCameraInfo();
-    p_can->camera_infos_[stream_id]->header = msg_ptr->header;
-    if (p_can->camera_infos_[stream_id]->width == 0 || p_can->camera_infos_[stream_id]->height == 0) {
-      ROS_WARN_STREAM_ONCE(
-          "The fields image_width and image_height seem not to be set in "
-          "the YAML specified by 'camera_info_url' parameter. Please set "
-          "them there, because actual image size and specified image size "
-          "can be different due to the region of interest (ROI) feature. In "
-          "the YAML the image size should be the one on which the camera was "
-          "calibrated. See CameraInfo.msg specification!");
-      p_can->camera_infos_[stream_id]->width = p_can->roi_.width;
-      p_can->camera_infos_[stream_id]->height = p_can->roi_.height;
-    }
-
-
-    p_can->cam_pubs_[stream_id].publish(msg_ptr, p_can->camera_infos_[stream_id]);
-
-    if (p_can->pub_ext_camera_info_) {
-      ExtendedCameraInfo extended_camera_info_msg;
-      p_can->extended_camera_info_mutex_.lock();
-
-      if (arv_camera_is_gv_device(p_can->p_camera_)) aravis::camera::gv::select_stream_channel(p_can->p_camera_, stream_id);
-
-      extended_camera_info_msg.camera_info = *(p_can->camera_infos_[stream_id]);
-      p_can->fillExtendedCameraInfoMessage(extended_camera_info_msg);
-      p_can->extended_camera_info_mutex_.unlock();
-      p_can->extended_camera_info_pubs_[stream_id].publish(extended_camera_info_msg);
-    }
-
-    // check PTP status, camera cannot recover from "Faulty" by itself
-    if (p_can->use_ptp_stamp_)
-      p_can->resetPtpClock();
-  }
-  else
-  {
-    if (arv_buffer_get_status(p_buffer) != ARV_BUFFER_STATUS_SUCCESS) {
-      ROS_WARN("(%s) Frame error: %s", frame_id.c_str(), szBufferStatusFromInt[arv_buffer_get_status(p_buffer)]);
-    }
     arv_stream_push_buffer(p_stream, p_buffer);
+    return;
   }
+
+  // at this point we have a valid buffer to work with
+
+  (p_can->n_buffers_)++;
+  // get the image message which wraps around this buffer
+  sensor_msgs::ImagePtr msg_ptr = (*(p_can->p_buffer_pools_[stream_id]))[p_buffer];
+  // fill the meta information of image message
+  // get acquisition time
+  guint64 t;
+  if (p_can->use_ptp_stamp_)
+    t = arv_buffer_get_timestamp(p_buffer);
+  else
+    t = arv_buffer_get_system_timestamp(p_buffer);
+  msg_ptr->header.stamp.fromNSec(t);
+  // get frame sequence number
+  msg_ptr->header.seq = arv_buffer_get_frame_id(p_buffer);
+  // fill other stream properties
+  msg_ptr->header.frame_id = frame_id;
+  msg_ptr->width = p_can->roi_.width;
+  msg_ptr->height = p_can->roi_.height;
+  msg_ptr->encoding = p_can->sensors_[stream_id]->pixel_format;
+  msg_ptr->step = (msg_ptr->width * p_can->sensors_[stream_id]->n_bits_pixel)/8;
+
+  // do the magic of conversion into a ROS format
+  if (p_can->convert_formats[stream_id]) {
+    sensor_msgs::ImagePtr cvt_msg_ptr = p_can->p_buffer_pools_[stream_id]->getRecyclableImg();
+    p_can->convert_formats[stream_id](msg_ptr, cvt_msg_ptr);
+    msg_ptr = cvt_msg_ptr;
+  }
+
+  // get current CameraInfo data
+  if (!p_can->camera_infos_[stream_id]) {
+    p_can->camera_infos_[stream_id].reset(new sensor_msgs::CameraInfo);
+  }
+  (*p_can->camera_infos_[stream_id]) = p_can->p_camera_info_managers_[stream_id]->getCameraInfo();
+  p_can->camera_infos_[stream_id]->header = msg_ptr->header;
+  if (p_can->camera_infos_[stream_id]->width == 0 || p_can->camera_infos_[stream_id]->height == 0) {
+    ROS_WARN_STREAM_ONCE(
+        "The fields image_width and image_height seem not to be set in "
+        "the YAML specified by 'camera_info_url' parameter. Please set "
+        "them there, because actual image size and specified image size "
+        "can be different due to the region of interest (ROI) feature. In "
+        "the YAML the image size should be the one on which the camera was "
+        "calibrated. See CameraInfo.msg specification!");
+    p_can->camera_infos_[stream_id]->width = p_can->roi_.width;
+    p_can->camera_infos_[stream_id]->height = p_can->roi_.height;
+  }
+
+
+  p_can->cam_pubs_[stream_id].publish(msg_ptr, p_can->camera_infos_[stream_id]);
+
+  if (p_can->pub_ext_camera_info_) {
+    ExtendedCameraInfo extended_camera_info_msg;
+    p_can->extended_camera_info_mutex_.lock();
+
+    if (arv_camera_is_gv_device(p_can->p_camera_)) aravis::camera::gv::select_stream_channel(p_can->p_camera_, stream_id);
+
+    extended_camera_info_msg.camera_info = *(p_can->camera_infos_[stream_id]);
+    p_can->fillExtendedCameraInfoMessage(extended_camera_info_msg);
+    p_can->extended_camera_info_mutex_.unlock();
+    p_can->extended_camera_info_pubs_[stream_id].publish(extended_camera_info_msg);
+  }
+
+  // check PTP status, camera cannot recover from "Faulty" by itself
+  if (p_can->use_ptp_stamp_)
+    p_can->resetPtpClock();
 }
 
 void CameraAravisNodelet::fillExtendedCameraInfoMessage(ExtendedCameraInfo &msg)

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -2130,7 +2130,7 @@ void CameraAravisNodelet::parseStringArgs(std::string in_arg_string, std::vector
   }
 }
 
-void CameraAravisNodelet::parseStringArgs2D(std::string in_arg_string, std::vector<std::vector<std::string>> &out_args) const
+void CameraAravisNodelet::parseStringArgs2D(std::string in_arg_string, std::vector<std::vector<std::string>> &out_args)
 {
   std::vector<std::string> streams;
 
@@ -2141,18 +2141,6 @@ void CameraAravisNodelet::parseStringArgs2D(std::string in_arg_string, std::vect
     std::vector<std::string> substreams;
     parseStringArgs(streams[i], substreams, ',');
     out_args.push_back(substreams);
-  }
-
-  if(!verbose_)
-    return;
-
-  ROS_INFO_STREAM("parsing: `" << in_arg_string << "`");
-
-  for(int i=0;i<out_args.size();++i)
-  {
-    ROS_INFO_STREAM("STREAM " << i);
-    for(int j=0;j<out_args[i].size();++j)
-      ROS_INFO_STREAM("  SUBSTREAM " << out_args[i][j]);
   }
 }
 

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -454,8 +454,17 @@ void CameraAravisNodelet::onInit()
   if (use_ptp_stamp_)
     resetPtpClock();
 
-  // enable multipart data
-  aravis::camera::set_multipart_output_format(p_camera_, true);
+  // enable multipart data if we configure for substreams
+  // chunked data is not implemented yet so we use multipart
+  bool has_substreams = std::any_of(streams_.begin(), streams_.end(),
+                                   [](const Stream &stream)
+                                     { return stream.substreams.size() > 1; });
+
+  if(has_substreams)
+  {
+    ROS_INFO("Detected substreams - enabling multipart output");
+    aravis::camera::set_multipart_output_format(p_camera_, true);
+  }
 
   // spawn camera stream in thread, so onInit() is not blocked
   spawning_ = true;

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -757,12 +757,12 @@ void CameraAravisNodelet::initCalibration()
     std::string camera_info_frame_id = config_.frame_id;
     Stream &src = streams_[i];
 
-    if(!src.stream_name.empty())
-      camera_info_frame_id = config_.frame_id + '/' + src.stream_name;
+    if(!src.name.empty())
+      camera_info_frame_id = config_.frame_id + '/' + src.name;
 
     // Use separate node handles for CameraInfoManagers when using a Multisource Camera
-    if(!src.stream_name.empty()) {
-      src.p_camera_info_node_handle.reset(new ros::NodeHandle(pnh, src.stream_name));
+    if(!src.name.empty()) {
+      src.p_camera_info_node_handle.reset(new ros::NodeHandle(pnh, src.name));
       src.p_camera_info_manager.reset(new camera_info_manager::CameraInfoManager(*src.p_camera_info_node_handle, camera_info_frame_id, calib_urls[i]));
 
     } else {
@@ -770,11 +770,11 @@ void CameraAravisNodelet::initCalibration()
     }
 
 
-    ROS_INFO("Reset %s Camera Info Manager", streams_[i].stream_name.c_str());
-    ROS_INFO("%s Calib URL: %s", streams_[i].stream_name.c_str(), calib_urls[i].c_str());
+    ROS_INFO("Reset %s Camera Info Manager", streams_[i].name.c_str());
+    ROS_INFO("%s Calib URL: %s", streams_[i].name.c_str(), calib_urls[i].c_str());
 
     // publish an ExtendedCameraInfo message
-    setExtendedCameraInfo(streams_[i].stream_name, i);
+    setExtendedCameraInfo(streams_[i].name, i);
   }
 }
 
@@ -887,8 +887,8 @@ void CameraAravisNodelet::spawnStream()
     // Set up image_raw
     std::string topic_name = this->getName();
     p_transport = new image_transport::ImageTransport(pnh);
-    if(num_streams_ != 1 || !streams_[i].stream_name.empty()) {
-      topic_name += "/" + streams_[i].stream_name;
+    if(num_streams_ != 1 || !streams_[i].name.empty()) {
+      topic_name += "/" + streams_[i].name;
     }
 
     streams_[i].cam_pub = p_transport->advertiseCamera(
@@ -1585,8 +1585,8 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, size_t stream_id)
   bool buffer_pool = (bool)streams_[stream_id].p_buffer_pool;
   bool has_subscribers = streams_[stream_id].cam_pub.getNumSubscribers();
 
-  const std::string &frame_id = streams_[stream_id].stream_name.empty() ? config_.frame_id :
-                                config_.frame_id + "/" + streams_[stream_id].stream_name;
+  const std::string &frame_id = streams_[stream_id].name.empty() ? config_.frame_id :
+                                config_.frame_id + "/" + streams_[stream_id].name;
 
   if (!buffer_success)
     ROS_WARN("(%s) Frame error: %s", frame_id.c_str(), szBufferStatusFromInt[arv_buffer_get_status(p_buffer)]);
@@ -1622,8 +1622,8 @@ void CameraAravisNodelet::processImageBuffer(ArvBuffer *p_buffer, size_t stream_
 {
   Stream & src = streams_[stream_id];
 
-  const std::string &frame_id = src.stream_name.empty() ? config_.frame_id :
-                                config_.frame_id + "/" + src.stream_name;
+  const std::string &frame_id = src.name.empty() ? config_.frame_id :
+                                config_.frame_id + "/" + src.name;
 
   // get the image message which wraps around this buffer
   sensor_msgs::ImagePtr msg_ptr = (*(src.p_buffer_pool))[p_buffer];

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1523,9 +1523,7 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, CameraAravisNodele
   arv_stream_get_n_buffers(p_stream, &n_available_buffers, NULL);
 
   if (n_available_buffers == 0)
-  {
     p_can->p_buffer_pools_[stream_id]->allocateBuffers(1);
-  }
 
   if(p_buffer == nullptr)
     return;
@@ -1545,7 +1543,6 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, CameraAravisNodele
 
   // at this point we have a valid buffer to work with
 
-  (p_can->n_buffers_)++;
   // get the image message which wraps around this buffer
   sensor_msgs::ImagePtr msg_ptr = (*(p_can->p_buffer_pools_[stream_id]))[p_buffer];
   // fill the meta information of image message

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -272,6 +272,11 @@ namespace aravis {
       LOG_GERROR_ARAVIS(err);
     }
 
+    void set_multipart_output_format(ArvCamera *cam, bool enable) {
+      GuardedGError err;
+      arv_camera_gv_set_multipart(cam, enable, err.storeError());
+      LOG_GERROR_ARAVIS(err);
+    }
 
     namespace bounds {
 
@@ -771,6 +776,9 @@ void CameraAravisNodelet::onInit()
   // spawn camera stream in thread, so onInit() is not blocked
   spawning_ = true;
   spawn_stream_thread_ = std::thread(&CameraAravisNodelet::spawnStream, this);
+
+  // enable multipart data
+  aravis::camera::set_multipart_output_format(p_camera_, true);
 }
 
 void CameraAravisNodelet::spawnStream()

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1552,11 +1552,8 @@ void CameraAravisNodelet::processBuffer(ArvBuffer *p_buffer, size_t stream_id)
   sensor_msgs::ImagePtr msg_ptr = (*(p_buffer_pools_[stream_id]))[p_buffer];
   // fill the meta information of image message
   // get acquisition time
-  guint64 t;
-  if (use_ptp_stamp_)
-    t = arv_buffer_get_timestamp(p_buffer);
-  else
-    t = arv_buffer_get_system_timestamp(p_buffer);
+  guint64 t = use_ptp_stamp_ ? arv_buffer_get_timestamp(p_buffer) : arv_buffer_get_system_timestamp(p_buffer);
+
   msg_ptr->header.stamp.fromNSec(t);
   // get frame sequence number
   msg_ptr->header.seq = arv_buffer_get_frame_id(p_buffer);

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1526,82 +1526,82 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, CameraAravisNodele
     p_can->p_buffer_pools_[stream_id]->allocateBuffers(1);
   }
 
-  if (p_buffer != NULL)
+  if(p_buffer == nullptr)
+    return;
+
+  if (arv_buffer_get_status(p_buffer) == ARV_BUFFER_STATUS_SUCCESS && p_can->p_buffer_pools_[stream_id]
+      && p_can->cam_pubs_[stream_id].getNumSubscribers())
   {
-    if (arv_buffer_get_status(p_buffer) == ARV_BUFFER_STATUS_SUCCESS && p_can->p_buffer_pools_[stream_id]
-        && p_can->cam_pubs_[stream_id].getNumSubscribers())
-    {
-      (p_can->n_buffers_)++;
-      // get the image message which wraps around this buffer
-      sensor_msgs::ImagePtr msg_ptr = (*(p_can->p_buffer_pools_[stream_id]))[p_buffer];
-      // fill the meta information of image message
-      // get acquisition time
-      guint64 t;
-      if (p_can->use_ptp_stamp_)
-        t = arv_buffer_get_timestamp(p_buffer);
-      else
-        t = arv_buffer_get_system_timestamp(p_buffer);
-      msg_ptr->header.stamp.fromNSec(t);
-      // get frame sequence number
-      msg_ptr->header.seq = arv_buffer_get_frame_id(p_buffer);
-      // fill other stream properties
-      msg_ptr->header.frame_id = frame_id;
-      msg_ptr->width = p_can->roi_.width;
-      msg_ptr->height = p_can->roi_.height;
-      msg_ptr->encoding = p_can->sensors_[stream_id]->pixel_format;
-      msg_ptr->step = (msg_ptr->width * p_can->sensors_[stream_id]->n_bits_pixel)/8;
-
-      // do the magic of conversion into a ROS format
-      if (p_can->convert_formats[stream_id]) {
-        sensor_msgs::ImagePtr cvt_msg_ptr = p_can->p_buffer_pools_[stream_id]->getRecyclableImg();
-        p_can->convert_formats[stream_id](msg_ptr, cvt_msg_ptr);
-        msg_ptr = cvt_msg_ptr;
-      }
-
-      // get current CameraInfo data
-      if (!p_can->camera_infos_[stream_id]) {
-        p_can->camera_infos_[stream_id].reset(new sensor_msgs::CameraInfo);
-      }
-      (*p_can->camera_infos_[stream_id]) = p_can->p_camera_info_managers_[stream_id]->getCameraInfo();
-      p_can->camera_infos_[stream_id]->header = msg_ptr->header;
-      if (p_can->camera_infos_[stream_id]->width == 0 || p_can->camera_infos_[stream_id]->height == 0) {
-        ROS_WARN_STREAM_ONCE(
-            "The fields image_width and image_height seem not to be set in "
-            "the YAML specified by 'camera_info_url' parameter. Please set "
-            "them there, because actual image size and specified image size "
-            "can be different due to the region of interest (ROI) feature. In "
-            "the YAML the image size should be the one on which the camera was "
-            "calibrated. See CameraInfo.msg specification!");
-        p_can->camera_infos_[stream_id]->width = p_can->roi_.width;
-        p_can->camera_infos_[stream_id]->height = p_can->roi_.height;
-      }
-
-
-      p_can->cam_pubs_[stream_id].publish(msg_ptr, p_can->camera_infos_[stream_id]);
-
-      if (p_can->pub_ext_camera_info_) {
-        ExtendedCameraInfo extended_camera_info_msg;
-        p_can->extended_camera_info_mutex_.lock();
-
-        if (arv_camera_is_gv_device(p_can->p_camera_)) aravis::camera::gv::select_stream_channel(p_can->p_camera_, stream_id);
-
-        extended_camera_info_msg.camera_info = *(p_can->camera_infos_[stream_id]);
-        p_can->fillExtendedCameraInfoMessage(extended_camera_info_msg);
-        p_can->extended_camera_info_mutex_.unlock();
-        p_can->extended_camera_info_pubs_[stream_id].publish(extended_camera_info_msg);
-      }
-
-      // check PTP status, camera cannot recover from "Faulty" by itself
-      if (p_can->use_ptp_stamp_)
-        p_can->resetPtpClock();
-    }
+    (p_can->n_buffers_)++;
+    // get the image message which wraps around this buffer
+    sensor_msgs::ImagePtr msg_ptr = (*(p_can->p_buffer_pools_[stream_id]))[p_buffer];
+    // fill the meta information of image message
+    // get acquisition time
+    guint64 t;
+    if (p_can->use_ptp_stamp_)
+      t = arv_buffer_get_timestamp(p_buffer);
     else
-    {
-      if (arv_buffer_get_status(p_buffer) != ARV_BUFFER_STATUS_SUCCESS) {
-        ROS_WARN("(%s) Frame error: %s", frame_id.c_str(), szBufferStatusFromInt[arv_buffer_get_status(p_buffer)]);
-      }
-      arv_stream_push_buffer(p_stream, p_buffer);
+      t = arv_buffer_get_system_timestamp(p_buffer);
+    msg_ptr->header.stamp.fromNSec(t);
+    // get frame sequence number
+    msg_ptr->header.seq = arv_buffer_get_frame_id(p_buffer);
+    // fill other stream properties
+    msg_ptr->header.frame_id = frame_id;
+    msg_ptr->width = p_can->roi_.width;
+    msg_ptr->height = p_can->roi_.height;
+    msg_ptr->encoding = p_can->sensors_[stream_id]->pixel_format;
+    msg_ptr->step = (msg_ptr->width * p_can->sensors_[stream_id]->n_bits_pixel)/8;
+
+    // do the magic of conversion into a ROS format
+    if (p_can->convert_formats[stream_id]) {
+      sensor_msgs::ImagePtr cvt_msg_ptr = p_can->p_buffer_pools_[stream_id]->getRecyclableImg();
+      p_can->convert_formats[stream_id](msg_ptr, cvt_msg_ptr);
+      msg_ptr = cvt_msg_ptr;
     }
+
+    // get current CameraInfo data
+    if (!p_can->camera_infos_[stream_id]) {
+      p_can->camera_infos_[stream_id].reset(new sensor_msgs::CameraInfo);
+    }
+    (*p_can->camera_infos_[stream_id]) = p_can->p_camera_info_managers_[stream_id]->getCameraInfo();
+    p_can->camera_infos_[stream_id]->header = msg_ptr->header;
+    if (p_can->camera_infos_[stream_id]->width == 0 || p_can->camera_infos_[stream_id]->height == 0) {
+      ROS_WARN_STREAM_ONCE(
+          "The fields image_width and image_height seem not to be set in "
+          "the YAML specified by 'camera_info_url' parameter. Please set "
+          "them there, because actual image size and specified image size "
+          "can be different due to the region of interest (ROI) feature. In "
+          "the YAML the image size should be the one on which the camera was "
+          "calibrated. See CameraInfo.msg specification!");
+      p_can->camera_infos_[stream_id]->width = p_can->roi_.width;
+      p_can->camera_infos_[stream_id]->height = p_can->roi_.height;
+    }
+
+
+    p_can->cam_pubs_[stream_id].publish(msg_ptr, p_can->camera_infos_[stream_id]);
+
+    if (p_can->pub_ext_camera_info_) {
+      ExtendedCameraInfo extended_camera_info_msg;
+      p_can->extended_camera_info_mutex_.lock();
+
+      if (arv_camera_is_gv_device(p_can->p_camera_)) aravis::camera::gv::select_stream_channel(p_can->p_camera_, stream_id);
+
+      extended_camera_info_msg.camera_info = *(p_can->camera_infos_[stream_id]);
+      p_can->fillExtendedCameraInfoMessage(extended_camera_info_msg);
+      p_can->extended_camera_info_mutex_.unlock();
+      p_can->extended_camera_info_pubs_[stream_id].publish(extended_camera_info_msg);
+    }
+
+    // check PTP status, camera cannot recover from "Faulty" by itself
+    if (p_can->use_ptp_stamp_)
+      p_can->resetPtpClock();
+  }
+  else
+  {
+    if (arv_buffer_get_status(p_buffer) != ARV_BUFFER_STATUS_SUCCESS) {
+      ROS_WARN("(%s) Frame error: %s", frame_id.c_str(), szBufferStatusFromInt[arv_buffer_get_status(p_buffer)]);
+    }
+    arv_stream_push_buffer(p_stream, p_buffer);
   }
 }
 

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -554,7 +554,7 @@ void CameraAravisNodelet::onInit()
     }
 
     if (implemented_features_["AcquisitionFrameRateEnable"]) {
-      aravis::device::feature::set_integer(p_device_, "AcquisitionFrameRateEnable", 1);
+      aravis::device::feature::set_boolean(p_device_, "AcquisitionFrameRateEnable", true);
     }
     if (implemented_features_["AcquisitionFrameRate"]) {
       aravis::camera::set_frame_rate(p_camera_, config_.AcquisitionFrameRate);

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1540,6 +1540,13 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, size_t stream_id)
   }
 
   // at this point we have a valid buffer to work with
+  processBuffer(p_buffer, stream_id);
+}
+
+void CameraAravisNodelet::processBuffer(ArvBuffer *p_buffer, size_t stream_id)
+{
+  const std::string &frame_id = stream_names_[stream_id].empty() ? config_.frame_id :
+                                config_.frame_id + "/" + stream_names_[stream_id];
 
   // get the image message which wraps around this buffer
   sensor_msgs::ImagePtr msg_ptr = (*(p_buffer_pools_[stream_id]))[p_buffer];
@@ -1604,6 +1611,7 @@ void CameraAravisNodelet::newBufferReady(ArvStream *p_stream, size_t stream_id)
   if (use_ptp_stamp_)
     resetPtpClock();
 }
+
 
 void CameraAravisNodelet::fillExtendedCameraInfoMessage(ExtendedCameraInfo &msg)
 {

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -426,6 +426,15 @@ void CameraAravisNodelet::onInit()
 
   initPixelFormats();
 
+  // set automatic rosparam features before bounds checking
+  // as some settings have side effects on sensor size/ROI
+  for(int i = 0; i < streams_.size(); i++)
+  {
+    if (arv_camera_is_gv_device(p_camera_))
+      aravis::camera::gv::select_stream_channel(p_camera_, i);
+    writeCameraFeaturesFromRosparam();
+  }
+
   getBounds();
 
   setUSBMode();
@@ -684,9 +693,6 @@ void CameraAravisNodelet::setCameraSettings()
       aravis::device::feature::set_string(p_device_, "TriggerSelector", "FrameStart");
       aravis::device::feature::set_string(p_device_, "TriggerMode", "Off");
     }
-
-    // possibly set or override from given parameter
-    writeCameraFeaturesFromRosparam();
   }
 }
 

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -530,7 +530,7 @@ void CameraAravisNodelet::initPixelFormats()
   ros::NodeHandle pnh = getPrivateNodeHandle();
   std::string pixel_format_args;
   std::vector<std::vector<std::string>> pixel_formats;
-  pnh.param("PixelFormat", pixel_format_args, pixel_format_args);
+  pnh.param("pixel_format", pixel_format_args, pixel_format_args);
   parseStringArgs2D(pixel_format_args, pixel_formats);
 
   // get pixel format name and translate into corresponding ROS name

--- a/src/camera_buffer_pool.cpp
+++ b/src/camera_buffer_pool.cpp
@@ -81,6 +81,9 @@ sensor_msgs::ImagePtr CameraBufferPool::operator[](ArvBuffer *buffer)
 
 void CameraBufferPool::allocateBuffers(size_t n)
 {
+  if(!n)
+    return;
+
   std::lock_guard<std::mutex> lock(mutex_);
 
   if (ARV_IS_STREAM(stream_))


### PR DESCRIPTION
Major refactoring/rewrite to support multipart data

## User level

- in params `channel_name`, `pixel_format` and `camera_info_url`
  - use `;` and `,` to separate multisource channels and multipart parts
  - multisource and multipart can be mixed for the same camera

### Multisource example

This was existing but changed `,` into `;`

```xml
  <arg name="channel_names"     default="vis;nir"/>
  <arg name="pixel_format"      default="BayerRG8;Mono8"/>
  <arg name="camera_info_url"   default="file://$(find camera_aravis)/launch/calib_vis.yaml;file://$(find camera_aravis)/launch/calib_nir.yaml"/>
```

### Multipart example

```xml
  <arg name="channel_names"        default="Intensity,Range"/>
  <arg name="pixel_format"             default="Mono16,Coord3D_C32f"/>
  <arg name="camera_info_url"       default=","/>
```

## Dependencies

Requires aravis >= [0.8.25](https://github.com/AravisProject/aravis/releases/tag/0.8.25) for multipart data support and fixes

Package not available in Ubuntu 20.04, a source build is needed.

## Code level

- general cleanup and simplification
  - a lot more could be done here
- encapsulated source data together (`Stream`)
- introduced `Substream` concept
  - each `Stream` has at least one `Substream`
  - multipart `Streams` have multiple `Substreams`
- added multipart data processing
- multipart uses buffer pools on `Stream` level  `Substream` levels
  - in multipart scenario there is no 1:1 mapping between ROS Image and aravis buffer
  - we still use Stream buffer pool for whole multipart buffer
  - but we also need buffer pools for each part data extracted from multipart buffer
- automatic rosparam -> GenICam is now done earlier
  - it had side effects that made things like ROI, sensor specs initialize differently internally and on device
- ...

## Breaking changes

- `,` now denotes multipart (earlier multisource/channel)
- `;` now denotes multisource/channel
- `PixelFormat` renamed to `pixel_format`
  - this doesn't correspond to GenICam `PixelFormat` in multisource and multipart scenarios
  - and generic rosparam -> GenICam layer would try to set it