### PR TITLE
mechanism for overriding pixel format used internally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
   tf
   tf2_ros
-  cv_bridge
 )
 
 # Version >= 0.8.17 -> ARV_UV_USB_MODE_ASYNC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,15 @@ find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
   tf
   tf2_ros
+  cv_bridge
 )
 
 # Version >= 0.8.17 -> ARV_UV_USB_MODE_ASYNC
+# Version >= 0.8.25 -> multipart support and fixes
 find_package(Aravis 0.8 REQUIRED)
 find_package(GLIB2 REQUIRED)
+
+find_package(OpenCV REQUIRED)
 
 generate_dynamic_reconfigure_options(cfg/CameraAravis.cfg)
 
@@ -58,7 +62,7 @@ generate_messages(
 )
 
 catkin_package(
-    DEPENDS Aravis GLIB2
+    DEPENDS Aravis GLIB2 OpenCV
     CATKIN_DEPENDS roscpp nodelet std_msgs sensor_msgs message_runtime image_transport camera_info_manager dynamic_reconfigure tf tf2_ros
     INCLUDE_DIRS
     LIBRARIES
@@ -69,6 +73,7 @@ include_directories(cfg
   ${catkin_INCLUDE_DIRS}
   ${Aravis_INCLUDE_DIRS}
   ${GLIB2_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
 )
 
 link_directories(${Aravis_LIBRARY_DIRS})
@@ -79,7 +84,7 @@ add_library(${PROJECT_NAME}
   src/conversion_utils.cpp
 )
 
-target_link_libraries(${PROJECT_NAME} ${Aravis_LIBRARIES} glib-2.0 gmodule-2.0 gobject-2.0 ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${Aravis_LIBRARIES} glib-2.0 gmodule-2.0 gobject-2.0 ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The camera_aravis driver has long history of multiple forks and now abandoned Gi
 
 ------------------------
 
-Tested with Aravis version 0.8.25, requires >= 0.8.23 for multipart data handling.
+Tested with Aravis version 0.8.27, requires >= 0.8.25 for multipart data handling.
 
 The basic command to run camera_aravis:
 
@@ -88,10 +88,29 @@ use `channel_name`, `pixel_format` and `camera_info_url` to specify multisource/
 - `;` seperates multi-source channels
 - `,` separates multipart parts
 - even if you don't specify `camera_info_urls` keep the correct structure, e.g. `","`
+- for multipart scenario the order of components should match order the device sends them in
+  - typically ordered by `ComponentIDValue`
 - for example multisource see `multisource_camera_aravis.launch`
 - for example multipart see `photoneo_motioncam.launch`
 
 ------------------------
+
+Parameter `pixel_format_internal` overrides pixel format used internally in `camera_aravis`.
+
+You may use it to implement device quirks like custom device pixel formats that are sent under different
+GenICam/GiGE-Vision pixel format.
+
+The `pixel_format_internal` works also with multisource and multipart devices
+- `;` seperates multi-source channels
+- `,` separates multipart components
+- you may specify partial overrides
+  - e.g. `"PhotoneoYCoCg420,"` means
+    - ovveride first component with `PhotoneoYCoCg420` pixel format
+    - keep the second component as is
+- for example multipart pixel format overriding see `photoneo_motioncam.launch`
+
+--------------------------
+
 It supports the dynamic_reconfigure protocol, and once the node is running, you may adjust
 its parameters by running the following and then manipulating the GUI:
 

--- a/include/camera_aravis/conversion_utils.h
+++ b/include/camera_aravis/conversion_utils.h
@@ -51,8 +51,9 @@ void unpack10PackedMonoImg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out
 void unpack12pImg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format);
 void unpack12PackedImg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format);
 void unpack565pImg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format);
-//quirky Photoneo MotionCam custom YCoCg reported as GenICam Mono16
-void photoneoYCoCg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format);
+
+//quirk pixel formats that are not defined in GenICam/GigE-Vision and come disguised as other format
+void photoneoYCoCg420(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format);
 
 const std::map<std::string, ConversionFunction> CONVERSIONS_DICTIONARY =
 {
@@ -70,8 +71,7 @@ const std::map<std::string, ConversionFunction> CONVERSIONS_DICTIONARY =
  { "R8", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO8) },
  { "G8", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO8) },
  { "B8", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO8) },
- { "Mono16", std::bind(&photoneoYCoCg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::RGB8) },
-// { "Mono16", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO16) },
+ { "Mono16", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO16) },
  { "Raw16", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO16) },
  { "R16", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO16) },
  { "G16", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO16) },
@@ -155,7 +155,9 @@ const std::map<std::string, ConversionFunction> CONVERSIONS_DICTIONARY =
  { "BayerBG12Packed", std::bind(&unpack12PackedImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::BAYER_BGGR16) },
  { "BayerGB12Packed", std::bind(&unpack12PackedImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::BAYER_GBRG16) },
  { "BayerGR12Packed", std::bind(&unpack12PackedImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::BAYER_GRBG16) },
- { "YUV422Packed", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::YUV422) }
+ { "YUV422Packed", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::YUV422) },
+  // Crazy internal pixel formats fixing various device quirks
+ { "PhotoneoYCoCg420", std::bind(&photoneoYCoCg420, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::RGB8) },
 };
 
 } // end namespace camera_aravis

--- a/include/camera_aravis/conversion_utils.h
+++ b/include/camera_aravis/conversion_utils.h
@@ -51,6 +51,8 @@ void unpack10PackedMonoImg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out
 void unpack12pImg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format);
 void unpack12PackedImg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format);
 void unpack565pImg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format);
+//quirky Photoneo MotionCam custom YCoCg reported as GenICam Mono16
+void photoneoYCoCg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format);
 
 const std::map<std::string, ConversionFunction> CONVERSIONS_DICTIONARY =
 {
@@ -68,7 +70,8 @@ const std::map<std::string, ConversionFunction> CONVERSIONS_DICTIONARY =
  { "R8", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO8) },
  { "G8", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO8) },
  { "B8", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO8) },
- { "Mono16", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO16) },
+ { "Mono16", std::bind(&photoneoYCoCg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::RGB8) },
+// { "Mono16", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO16) },
  { "Raw16", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO16) },
  { "R16", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO16) },
  { "G16", std::bind(&renameImg, std::placeholders::_1, std::placeholders::_2, sensor_msgs::image_encodings::MONO16) },

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -11,6 +11,7 @@
 
   <arg name="channel_names"            default="Intensity,Range"/>
   <arg name="pixel_format"             default="Mono16,Coord3D_C32f"/>
+  <arg name="pixel_format_internal"    default="PhotoneoYCoCg420,"/>
 
   <arg name="width"                    default="1120"/>
   <arg name="height"                   default="800"/>
@@ -36,7 +37,8 @@
 
     <param name="publish_tf"           value="true"/>
     <param name="tf_publish_rate"      value="$(arg fps)"/>
-    <param name="pixel_format"          value="$(arg pixel_format)"/>
+    <param name="pixel_format"         value="$(arg pixel_format)"/>
+    <param name="pixel_format_internal" value="$(arg pixel_format_internal)"/>
 
     <!-- use GenICam SFNC names as stream control parameters -->
     <param name="Width"                value="$(arg width)"/>

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -43,7 +43,7 @@
     <!-- use GenICam SFNC names as stream control parameters -->
     <param name="Width"                value="$(arg width)"/>
     <param name="Height"               value="$(arg height)"/>
-    <param name="AcquisitionFrameRate" type="double" value="$(arg fps)"/>
+    <param name="AcquisitionFrameRate" value="$(arg fps)" type="double"/>
 
     <param name="Gamma"                value="1.0"/>
     <param name="Gain"                 value="0.0"/>
@@ -54,6 +54,9 @@
 
     <!-- Needed for higher resolution -->
     <param name="OutputTopology"       value="RegularGrid"/>
+
+    <param name="ColorSettings_ISO"    value="200" type="int"/>
+
   </node>
 
 </launch>

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -43,7 +43,7 @@
     <param name="Height"               value="$(arg height)"/>
     <param name="AcquisitionFrameRate" type="double" value="$(arg fps)"/>
 
-    <param name="Gamma"                value="0.41"/>
+    <param name="Gamma"                value="1.0"/>
     <param name="Gain"                 value="0.0"/>
     <param name="AutoFunctionsROIPreset" value="AutoFunctionsROIPreset_Full"/>
     <param name="ExposureAuto"         value="Continuous"/>

--- a/package.xml
+++ b/package.xml
@@ -33,8 +33,11 @@
 
   <build_depend>aravis-dev</build_depend>
   <build_depend>libglib-dev</build_depend> <!-- Bugfix: Missing dependency in Debian Buster -->
+  <build_depend>cv_bridge</build_depend>
   <build_depend>message_generation</build_depend>
+
   <exec_depend>message_runtime</exec_depend>
+  <exec_depend>cv_bridge</exec_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />

--- a/package.xml
+++ b/package.xml
@@ -33,11 +33,9 @@
 
   <build_depend>aravis-dev</build_depend>
   <build_depend>libglib-dev</build_depend> <!-- Bugfix: Missing dependency in Debian Buster -->
-  <build_depend>cv_bridge</build_depend>
   <build_depend>message_generation</build_depend>
 
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend>cv_bridge</exec_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -1850,8 +1850,6 @@ void CameraAravisNodelet::processPartBuffer(ArvBuffer *p_buffer, size_t stream_i
 
   // do the magic of conversion into a ROS format
   if (substream.convert_format) {
-    //we might consider making it a separate pool
-    //as the image size here may differ
     sensor_msgs::ImagePtr cvt_msg_ptr = substream.p_buffer_pool->getRecyclableImg();
     substream.convert_format(msg_ptr, cvt_msg_ptr);
     msg_ptr = cvt_msg_ptr;

--- a/src/conversion_utils.cpp
+++ b/src/conversion_utils.cpp
@@ -470,7 +470,7 @@ static RGBType photoneoYCoCgPixelRGB(const ChannelType y, const ChannelType co, 
  * @see https://en.wikipedia.org/wiki/YCoCg
  */
 
-void photoneoYCoCg(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format)
+void photoneoYCoCg420(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, const std::string out_format)
 {
   if (!in)
   {

--- a/src/conversion_utils.cpp
+++ b/src/conversion_utils.cpp
@@ -442,6 +442,8 @@ namespace photoneo
 
       const ChannelType delta = (1 << (PIXEL_DEPTH - 1)); // 2^9
       const ChannelType maxValue = 2 * delta - 1; //2^10 - 1 = 1023
+      const ChannelType maxTo8BitDiv = 4; //1023 max, we want max 255
+
       ChannelType r1 = 2 * y + co;
       ChannelType r = r1 > cg ? (r1 - cg) / 2 : ChannelType(0);
       ChannelType g1 = y + cg / 2;
@@ -450,7 +452,9 @@ namespace photoneo
       ChannelType b2 = (co + cg) / 2;
       ChannelType b = b1 > b2 ? (b1 - b2) : ChannelType(0);
 
-      return {(uint8_t)(std::min(r, maxValue) / 4), (uint8_t)(std::min(g, maxValue) / 4), (uint8_t)(std::min(b, maxValue) / 4)};
+      return {(uint8_t)(std::min(r, maxValue) / maxTo8BitDiv),
+              (uint8_t)(std::min(g, maxValue) / maxTo8BitDiv),
+              (uint8_t)(std::min(b, maxValue) / maxTo8BitDiv)};
   }
 
 } //namespace photoneo

--- a/src/conversion_utils.cpp
+++ b/src/conversion_utils.cpp
@@ -487,7 +487,7 @@ void photoneoYCoCg420(sensor_msgs::ImagePtr& in, sensor_msgs::ImagePtr& out, con
 
   if (in->encoding != "Mono16")
   {
-    ROS_WARN("camera_aravis::photoneoMotionCamYCoCg(): expecs Mono16 encoded custom YCoCg 4:2:0 subsampled data.");
+    ROS_WARN("camera_aravis::photoneoMotionCamYCoCg(): expects Mono16 encoded custom YCoCg 4:2:0 subsampled data.");
     return;
   }
 


### PR DESCRIPTION
## User level

Parameter `pixel_format_internal` overrides pixel format used internally in `camera_aravis`.

Use it to implement device quirks like custom device pixel formats that are sent under different
GenICam/GiGE-Vision pixel format.

The `pixel_format_internal` works also with multisource and multipart devices
- `;` seperates multi-source channels
- `,` separates multipart components
- you may specify partial overrides
  - e.g. `"PhotoneoYCoCg420,"` means
    - ovveride first component with `PhotoneoYCoCg420` pixel format
    - keep the second component as is
- for example multipart pixel format overriding see `photoneo_motioncam.launch`

## Implementation

- added `PhotoneoYCoCg420` internal pixel format
  - 4:2:0 subsampled YCoCg with Photoneo MotionCam quirks
- used pixel format overriding mechanism in example launchfile to
  - override GenICam `Mono16` for first component
  - with `PhotoneoYCoCg420`
  - this effectively
    - uses `Mono16` to communicate data over wire 
    - uses `PhotoneoYCoCg420` to perform conversion to RGB

## Documentation

Minimal documentation in readme

## Notes

 `PhotoneoYCoCg420` pixel format conversion may need revisiting for performance reasons