### PR TITLE
calibration for MotionCam M+

### DIFF
--- a/calibration/photoneo/motioncam_m_plus/Range.yaml
+++ b/calibration/photoneo/motioncam_m_plus/Range.yaml
@@ -1,0 +1,55 @@
+# Device: 0
+#  Name:                    MotionCam-3D-TRD-058
+#  Hardware Identification: TRD-058
+#  Type:                    MotionCam-3D
+#  Firmware version:        1.10.1
+#  Variant:                 M+
+#  IsFileCamera:            No
+#  Feature-Alpha:           No
+#  Feature-Color:           Yes
+#  Status:                  Attached to PhoXi Control. Ready to connect
+
+# Device: 1
+#  Name:                    basic-example
+#  Hardware Identification: InstalledExamples-basic-example
+#  Type:                    PhoXi3DScan
+#  Firmware version:        
+#  Variant:                 
+#  IsFileCamera:            Yes
+#  Feature-Alpha:           No
+#  Feature-Color:           No
+#  Status:                  Not Attached to PhoXi Control. Ready to connect
+
+# Device: 2
+#  Name:                    color-example
+#  Hardware Identification: InstalledExamples-color-example
+#  Type:                    MotionCam-3D
+#  Firmware version:        
+#  Variant:                 
+#  IsFileCamera:            Yes
+#  Feature-Alpha:           No
+#  Feature-Color:           Yes
+#  Status:                  Not Attached to PhoXi Control. Ready to connect
+
+# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: TRD-058
+
+image_width: 1120
+image_height: 800
+camera_name: TRD-058
+camera_matrix: 
+  rows: 3
+  cols: 3
+  data: [1158.77, 0, 569.003, 0, 1158.7, 392.4, 0, 0, 1]
+distortion_model: plumb_bob
+distortion_coefficients: 
+  rows: 1
+  cols: 5
+  data: [-0.0810895, 0.105247, 9.91814e-05, 0.00054898, 0.0366575]
+rectification_matrix: 
+  rows: 3
+  cols: 3
+  data: [1, 0, 0, 0, 1, 0, 0, 0, 1]
+projection_matrix: 
+  rows: 3
+  cols: 4
+  data: [1158.77, 0, 569.003, 0, 0, 1158.7, 392.4, 0, 0, 0, 1, 0]

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -7,7 +7,6 @@
 
   <arg name="sensor_name"              default="aravis_camera"/>
   <arg name="serial_no"                default=""/>
-  <arg name="camera_info_url"          default=","/>
 
   <!-- MotionCam
        - with TextureSource = Color delivers Intensity as custom YCoCg 4:2:0 pixel format in GenICam/GigE-Vision Mono16
@@ -17,6 +16,10 @@
   <arg name="texture_source"           default="Color"/>
   <arg name="pixel_format"             default="Mono16,Coord3D_C32f"/>
   <arg name="pixel_format_internal"    default="PhotoneoYCoCg420,FloatToUint"/>
+
+  <!-- the Range and Intensity data is aligned, we use the same calibration twice  -->
+  <arg name="camera_info_url"          default="file://$(find camera_aravis)/calibration/photoneo/motioncam_m_plus/Range.yaml,file://$(find camera_aravis)/calibration/photoneo/motioncam_m_plus/Range.yaml"/>
+
 
   <arg name="width"                    default="1120"/>
   <arg name="height"                   default="800"/>


### PR DESCRIPTION
Calibration file for MotionCam M+ and launchfile changes

# Prerequisites

With newer firmware/PhoxiControl
- to avoid PhoXi Control overriding settings set by GenICam during calibration procedure.
  - connect to camera with PhoXi control
  - make sure User Profile is set to <NON_SELECTED>
  - and mark it as startup profile

After extracting calibrations you may set again profile in PhoXiControl.

# Calibration

Generated with:
- [Extend-Robotics/photoneo-cpp-examples/PhoXiAPI/FrameCalibrationToROS](https://github.com/Extend-Robotics/photoneo-cpp-examples/tree/extend/PhoXiAPI/FrameCalibrationToROS)
- as documented

Calibration is shared for `Range` and device aligned `Intensity` (texture)

## Procedure Used

1. Start and stop `camera_aravis` for Photoneo MotionCam

```bash
roslaunch camera_aravis photoneo_motioncam.launch
# stop with `Ctrl+C` after init
```



2. Start `PhoXi Control` and connect to MotionCam


3. Run `FrameCalibrationToROS` and save the calibration

```bash
./FrameCalibrationToROS > Range.yaml
```

```bash
# copy calibration here
roscd camera_aravis/calibration/photoneo/motioncam_m_plus/
```
------------------

Explanation:
1. Sets the settings for which we want calibration
2. Required for Photoneo API to work and calibration tool to connect to the right sensor
3. Dumps calibration to ROS compatible yaml using API

## Sample Result

| Depth Cloud `Range` | Depth Cloud + `Range` + `Intensity`  |
|------------------------------|--------------------------------------------------|
| ![image](https://github.com/Extend-Robotics/camera_aravis/assets/9095769/adf557f1-029b-4fae-8ea2-770a9a8dd0b2) | ![image](https://github.com/Extend-Robotics/camera_aravis/assets/9095769/a519a09d-0f12-494d-a860-45acc6f68043) |

## Sample Calibration

```yaml
# Device: 0
#  Name:                    MotionCam-3D-TRD-058
#  Hardware Identification: TRD-058
#  Type:                    MotionCam-3D
#  Firmware version:        1.10.1
#  Variant:                 M+
#  IsFileCamera:            No
#  Feature-Alpha:           No
#  Feature-Color:           Yes
#  Status:                  Attached to PhoXi Control. Ready to connect

# Device: 1
#  Name:                    basic-example
#  Hardware Identification: InstalledExamples-basic-example
#  Type:                    PhoXi3DScan
#  Firmware version:        
#  Variant:                 
#  IsFileCamera:            Yes
#  Feature-Alpha:           No
#  Feature-Color:           No
#  Status:                  Not Attached to PhoXi Control. Ready to connect

# Device: 2
#  Name:                    color-example
#  Hardware Identification: InstalledExamples-color-example
#  Type:                    MotionCam-3D
#  Firmware version:        
#  Variant:                 
#  IsFileCamera:            Yes
#  Feature-Alpha:           No
#  Feature-Color:           Yes
#  Status:                  Not Attached to PhoXi Control. Ready to connect

# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: TRD-058

image_width: 1120
image_height: 800
camera_name: TRD-058
camera_matrix: 
  rows: 3
  cols: 3
  data: [1158.77, 0, 569.003, 0, 1158.7, 392.4, 0, 0, 1]
distortion_model: plumb_bob
distortion_coefficients: 
  rows: 1
  cols: 5
  data: [-0.0810895, 0.105247, 9.91814e-05, 0.00054898, 0.0366575]
rectification_matrix: 
  rows: 3
  cols: 3
  data: [1, 0, 0, 0, 1, 0, 0, 0, 1]
projection_matrix: 
  rows: 3
  cols: 4
  data: [1158.77, 0, 569.003, 0, 0, 1158.7, 392.4, 0, 0, 0, 1, 0]
```