### PR TITLE
rework frame_id support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ To specify which camera to open, via a parameter:
 
 camera_aravis supports multisource cameras and multipart data
 
-use `channel_name`, `pixel_format` and `camera_info_url` to specify multisource/multipart camera
+use `channel_name`, `pixel_format`, `camera_info_url`, `frame_id` to specify multisource/multipart camera
 - `;` seperates multi-source channels
 - `,` separates multipart parts
 - even if you don't specify `camera_info_urls` keep the correct structure, e.g. `","`
+- specify `frame_id` for each source/part, e.g. `"camera_optical_frame,camera_optical_frame"`
 - for multipart scenario the order of components should match order the device sends them in
   - typically ordered by `ComponentIDValue`
 - for example multisource see `multisource_camera_aravis.launch`

--- a/cfg/CameraAravis.cfg
+++ b/cfg/CameraAravis.cfg
@@ -42,7 +42,6 @@ gen.add("TriggerSource",        str_t,    SensorLevels.RECONFIGURE_RUNNING, "Tri
 gen.add("softwaretriggerrate",  double_t, SensorLevels.RECONFIGURE_RUNNING, "Software Trigger Rate (hz)", 100.0, 0.01, 200.0)
 
 gen.add("FocusPos",             int_t,    SensorLevels.RECONFIGURE_RUNNING, "FocusPos",             32767, 0, 65535)
-gen.add("frame_id",             str_t,    SensorLevels.RECONFIGURE_RUNNING, "ROS camera frame",     "camera")
 gen.add("mtu",                  int_t,    SensorLevels.RECONFIGURE_RUNNING, "mtu",                  1500, 576, 9000)
 
 exit(gen.generate(PACKAGE, "camera_aravis_params", "CameraAravis"))

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -3,6 +3,7 @@
  * camera_aravis
  *
  * Copyright © 2022 Fraunhofer IOSB and contributors
+ * Copyright © 2023 Extend Robotics Limited and contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -91,7 +92,6 @@ private:
   std::string guid_ = "";
   bool use_ptp_stamp_ = false;
   bool pub_ext_camera_info_ = false;
-  bool pub_tf_optical_ = false;
 
   ArvCamera *p_camera_ = NULL;
   ArvDevice *p_device_ = NULL;
@@ -109,6 +109,7 @@ private:
   {
     Sensor sensor;
     std::string name;
+    std::string frame_id;
     //pool for multipart path where images don't map 1:1 to aravis buffers
     CameraBufferPool::Ptr p_buffer_pool;
     ConversionFunction convert_format;
@@ -136,6 +137,7 @@ private:
   int32_t acquire_ = 0;
 
   virtual void onInit() override;
+  std::vector<std::vector<std::string>> getFrameIds(const std::vector<std::vector<std::string>> &substream_names) const;
   void connectToCamera();
   int discoverStreams(size_t stream_names_size);
   void disableComponents();
@@ -144,7 +146,6 @@ private:
   void setUSBMode();
   void setCameraSettings();
   void readCameraSettings();
-  void publish_tf_optical();
   void initCalibration();
   void printCameraInfo();
 
@@ -221,8 +222,6 @@ protected:
   // triggers a shot at regular intervals, sleeps in between
   void softwareTriggerLoop();
 
-  void publishTfLoop(double rate);
-
   void discoverFeatures();
 
   static void parseStringArgs(std::string in_arg_string, std::vector<std::string> &out_args, char seprator = ';');
@@ -240,12 +239,6 @@ protected:
 
   std::unique_ptr<dynamic_reconfigure::Server<Config> > reconfigure_server_;
   boost::recursive_mutex reconfigure_mutex_;
-
-  std::unique_ptr<tf2_ros::StaticTransformBroadcaster> p_stb_;
-  std::unique_ptr<tf2_ros::TransformBroadcaster> p_tb_;
-  geometry_msgs::TransformStamped tf_optical_;
-  std::thread tf_dyn_thread_;
-  std::atomic_bool tf_thread_active_;
 
   CameraAutoInfo auto_params_;
   ros::Publisher auto_pub_;

--- a/launch/camera_aravis.launch
+++ b/launch/camera_aravis.launch
@@ -30,9 +30,6 @@
       <param name="camera_info_url"      value="$(arg camera_info_url)"/>
       <param name="frame_id"             value="$(arg sensor_name)"/>
 
-      <param name="publish_tf"           value="true"/>
-      <param name="tf_publish_rate"      value="$(arg fps)"/>
-
       <param name="pixel_format"          value="$(arg pixel_format)"/>
 
       <!-- use GenICam SFNC names as stream control parameters -->

--- a/launch/multisource_camera_aravis.launch
+++ b/launch/multisource_camera_aravis.launch
@@ -10,6 +10,8 @@
   <arg name="camera_info_url"          default="file://$(find camera_aravis)/calibration/calib_vis.yaml;file://$(find camera_aravis)/calibration/calib_nir.yaml"/>
 
   <arg name="channel_names"            default="vis;nir"/>
+  <arg name="frame_id"                 default="$(arg sensor_name);$(arg sensor_name)"/>
+
   <arg name="pixel_format"             default="BayerRG8;Mono8"/>
   <arg name="width"                    default="2048"/>
   <arg name="height"                   default="1536"/>
@@ -28,13 +30,11 @@
 
       <param name="guid"                 value="$(arg serial_no)"/>
       <param name="camera_info_url"      value="$(arg camera_info_url)"/>
-      <param name="frame_id"             value="$(arg sensor_name)"/>
+      <param name="frame_id"             value="$(arg frame_id)"/>
 
       <!-- Multisource Camera -->
       <param name="channel_names" value="$(arg channel_names)"/>
 
-      <param name="publish_tf"           value="true"/>
-      <param name="tf_publish_rate"      value="$(arg fps)"/>
       <param name="pixel_format"          value="$(arg pixel_format)"/>
 
       <!-- use GenICam SFNC names as stream control parameters -->

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -19,7 +19,8 @@
 
   <!-- the Range and Intensity data is aligned, we use the same calibration twice  -->
   <arg name="camera_info_url"          default="file://$(find camera_aravis)/calibration/photoneo/motioncam_m_plus/Range.yaml,file://$(find camera_aravis)/calibration/photoneo/motioncam_m_plus/Range.yaml"/>
-
+  <!-- and publish under same frame id  -->
+  <arg name="frame_id"                 default="range_optical_frame,range_optical_frame"/>
 
   <arg name="width"                    default="1120"/>
   <arg name="height"                   default="800"/>
@@ -38,13 +39,11 @@
 
     <param name="guid"                 value="$(arg serial_no)"/>
     <param name="camera_info_url"      value="$(arg camera_info_url)"/>
-    <param name="frame_id"             value="$(arg sensor_name)"/>
+    <param name="frame_id"             value="$(arg frame_id)"/>
 
     <!-- Multistream Camera (not Multisource) -->
     <param name="channel_names"        value="$(arg channel_names)"/>
 
-    <param name="publish_tf"           value="true"/>
-    <param name="tf_publish_rate"      value="$(arg fps)"/>
     <param name="pixel_format"         value="$(arg pixel_format)"/>
     <param name="pixel_format_internal" value="$(arg pixel_format_internal)"/>
 


### PR DESCRIPTION
Existing support is not correct.

This pull request:
- takes some steps back removing existing frame_id code
- starts with simple frame_id support
  - also for multisource and multipart

More work can be added on top

------------------------------------------------------

- remove frame_id from dynamic reconfigure
  - it is terrible idea to reconfigure frame_id at runtime
  - dynamic reconfigure was overwriting launchfile frame_id with `camera` on init
- isolate code related to frame_ids
  - were constructed in multiple places
  - without consistency
- remove tf optical publishing code
  - weren't used (images published under different frames!)
  - doesn't probably even need to be coded
  - didn't support multisource and multipart
- add support for defining multisource and multipart frame_ids
  - support multipart `,` and multisource `;` separators in args