### PR TITLE
fix dynamic reconfigure defaults overwriting auto rosparam -> GenICam params

### DIFF
--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -227,6 +227,7 @@ protected:
   static void parseStringArgs(std::string in_arg_string, std::vector<std::string> &out_args, char seprator = ';');
   static void parseStringArgs2D(std::string in_arg_string, std::vector<std::vector<std::string>> &out_args);
 
+  void writeCameraFeaturesFromRosparamForStreams();
   // WriteCameraFeaturesFromRosparam()
   // Read ROS parameters from this node's namespace, and see if each parameter has a similarly named & typed feature in the camera.  Then set the
   // camera feature to that value.  For example, if the parameter camnode/Gain is set to 123.0, then we'll write 123.0 to the Gain feature

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -2,10 +2,9 @@
 <launch>
   <arg name="load_manager"             default="true"/>
   <arg name="manager_name"             default="camera_manager"/>
-  <arg name="manager"                  value="/$(arg manager_name)"/>
   <arg name="manager_threads"          default="4"/>
 
-  <arg name="sensor_name"              default="aravis_camera"/>
+  <arg name="sensor_name"              default="camera"/>
   <arg name="serial_no"                default=""/>
 
   <!-- MotionCam
@@ -34,34 +33,37 @@
   </node>
 
   <!-- Aravis RGB camera nodelet -->
-  <node pkg="nodelet" type="nodelet" name="$(arg sensor_name)" args="standalone camera_aravis/CameraAravisNodelet" output="screen">
-    <param name="verbose"              value="$(arg verbose)"/>
+  <node pkg="nodelet" type="nodelet" name="$(arg sensor_name)" args="load camera_aravis/CameraAravisNodelet $(arg manager_name)" output="screen">
+    <param name="verbose"                value="$(arg verbose)"/>
 
-    <param name="guid"                 value="$(arg serial_no)"/>
-    <param name="camera_info_url"      value="$(arg camera_info_url)"/>
-    <param name="frame_id"             value="$(arg frame_id)"/>
+    <param name="guid"                   value="$(arg serial_no)"/>
 
     <!-- Multistream Camera (not Multisource) -->
-    <param name="channel_names"        value="$(arg channel_names)"/>
+    <param name="channel_names"          value="$(arg channel_names)"/>
 
-    <param name="pixel_format"         value="$(arg pixel_format)"/>
-    <param name="pixel_format_internal" value="$(arg pixel_format_internal)"/>
+    <param name="pixel_format"           value="$(arg pixel_format)"/>
+    <param name="pixel_format_internal"  value="$(arg pixel_format_internal)"/>
+
+    <param name="frame_id"               value="$(arg frame_id)"/>
+    <param name="camera_info_url"        value="$(arg camera_info_url)"/>
 
     <!-- use GenICam SFNC names as stream control parameters -->
-    <param name="Width"                value="$(arg width)"/>
-    <param name="Height"               value="$(arg height)"/>
-    <param name="AcquisitionFrameRate" value="$(arg fps)" type="double"/>
+    <param name="Width"                  value="$(arg width)"/>
+    <param name="Height"                 value="$(arg height)"/>
 
-    <param name="Gamma"                value="1.0"/>
-    <param name="Gain"                 value="0.0"/>
+    <param name="AcquisitionFrameRate"   value="$(arg fps)" type="double"/>
+    <param name="Gamma"                  value="1.0"/>
+    <param name="Gain"                   value="0.0"/>
     <param name="AutoFunctionsROIPreset" value="AutoFunctionsROIPreset_Full"/>
-    <param name="ExposureAuto"         value="Continuous"/>
-    <param name="GainAuto"             value="Continuous"/>
-    <param name="BalanceWhiteAuto"     value="Continuous"/>
+    <param name="ExposureAuto"           value="Continuous"/>
+    <param name="GainAuto"               value="Continuous"/>
+    <param name="BalanceWhiteAuto"       value="Continuous"/>
 
-    <param name="OutputTopology"       value="RegularGrid"/>  <!-- RegularGrid required for higher resolution and modelling optics with intrinsics/distortion-->
-    <param name="ColorSettings_ISO"    value="200" type="int"/>
-    <param name="TextureSource"        value="$(arg texture_source)" type="str"/>
+    <!-- RegularGrid required for higher resolution and modelling optics with intrinsics/distortion-->
+    <param name="OutputTopology"         value="RegularGrid"/>
+    <param name="ColorSettings_ISO"      value="200" type="int"/>
+    <param name="ColorSettings_Exposure" value="20.480000"/>
+    <param name="TextureSource"          value="$(arg texture_source)" type="str"/>
 
   </node>
 

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -444,18 +444,19 @@ void CameraAravisNodelet::onInit()
 
   // set automatic rosparam features before bounds checking
   // as some settings have side effects on sensor size/ROI
-  for(int i = 0; i < streams_.size(); i++)
-  {
-    if (arv_camera_is_gv_device(p_camera_))
-      aravis::camera::gv::select_stream_channel(p_camera_, i);
-    writeCameraFeaturesFromRosparam();
-  }
+  // we will also set them second time (!)
+  writeCameraFeaturesFromRosparamForStreams();
 
   getBounds();
 
   setUSBMode();
 
   setCameraSettings();
+
+  // set automatic rosparam features before camera readout
+  // we do it second time here (!)
+  // to prevent dynamic reconfigure defualts overwriting node params
+  writeCameraFeaturesFromRosparamForStreams();
 
   readCameraSettings();
 
@@ -2132,6 +2133,16 @@ void CameraAravisNodelet::parseStringArgs2D(std::string in_arg_string, std::vect
     std::vector<std::string> substreams;
     parseStringArgs(streams[i], substreams, ',');
     out_args.push_back(substreams);
+  }
+}
+
+void CameraAravisNodelet::writeCameraFeaturesFromRosparamForStreams()
+{
+  for(int i = 0; i < streams_.size(); i++)
+  {
+    if (arv_camera_is_gv_device(p_camera_))
+      aravis::camera::gv::select_stream_channel(p_camera_, i);
+    writeCameraFeaturesFromRosparam();
   }
 }
 


### PR DESCRIPTION
In #2 we moved auto rosparam -> GenICam earlier to avoid side effects those params have on ROI/resolution

This has other side effects
- dynamic reconfigure defaults overwrite launchfile params

For now we use auto rosparams twice during init to prevent both side effects
- before ROI setup
- after camera settings setup