### PR TITLE
decouple application buffer processing from aravis

### DIFF
--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -189,14 +189,14 @@ protected:
   // Buffer Callback Helper
   void newBufferReady(ArvStream *p_stream, size_t stream_id);
 
-  // Process Validated Buffer
-  void processBuffer(ArvBuffer *p_buffer, size_t stream_id);
-
-  void processImageBuffer(ArvBuffer *p_buffer, size_t stream_id);
-  void processChunkDataBuffer(ArvBuffer *p_buffer, size_t stream_id);
-  void processMultipartBuffer(ArvBuffer *p_buffer, size_t stream_id);
+  // Delegate validated buffer to substream(s) thread(s)
+  void delegateBuffer(ArvBuffer *p_buffer, size_t stream_id);
+  void delegateBuffer(ArvBuffer *p_buffer, size_t stream_id, size_t substreams);
+  void delegateChunkDataBuffer(ArvBuffer *p_buffer, size_t stream_id);
 
   void substreamThreadMain(const int stream_id, const int substream_id);
+
+  void processImageBuffer(ArvBuffer *p_buffer, size_t stream_id, sensor_msgs::ImagePtr &msg_ptr);
   void processPartBuffer(ArvBuffer *p_buffer, size_t stream_id, size_t substream_id);
 
   void fillImage(const sensor_msgs::ImagePtr &msg_ptr, ArvBuffer *p_buffer, const std::string frame_id, const Sensor& sensor);

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -123,8 +123,8 @@ private:
 
     std::thread buffer_thread;
     bool buffer_thread_stop;
-    //std::mutex buffer_data_mutex;
-    //std::condition_variable buffer_ready_condition;
+    std::mutex buffer_data_mutex;
+    std::condition_variable buffer_ready_condition;
   };
 
   // a single stream may transfer multiple substreams (multipart/chunked data)

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -189,14 +189,14 @@ protected:
   // Buffer Callback Helper
   void newBufferReady(ArvStream *p_stream, size_t stream_id);
 
-  void substreamThreadMain(const int stream_id, const int substream_id);
-
   // Process Validated Buffer
   void processBuffer(ArvBuffer *p_buffer, size_t stream_id);
 
   void processImageBuffer(ArvBuffer *p_buffer, size_t stream_id);
   void processChunkDataBuffer(ArvBuffer *p_buffer, size_t stream_id);
   void processMultipartBuffer(ArvBuffer *p_buffer, size_t stream_id);
+
+  void substreamThreadMain(const int stream_id, const int substream_id);
   void processPartBuffer(ArvBuffer *p_buffer, size_t stream_id, size_t substream_id);
 
   void fillImage(const sensor_msgs::ImagePtr &msg_ptr, ArvBuffer *p_buffer, const std::string frame_id, const Sensor& sensor);

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -125,6 +125,10 @@ private:
     bool buffer_thread_stop;
     std::mutex buffer_data_mutex;
     std::condition_variable buffer_ready_condition;
+
+    //ROS image wrapping around aravis buffer data and correspoding aravis buffer
+    sensor_msgs::ImagePtr p_buffer_image;
+    ArvBuffer *p_buffer;
   };
 
   // a single stream may transfer multiple substreams (multipart/chunked data)
@@ -185,7 +189,7 @@ protected:
   // Buffer Callback Helper
   void newBufferReady(ArvStream *p_stream, size_t stream_id);
 
-  void substreamBufferThreadMain(const int stream_id, const int substream_id);
+  void substreamThreadMain(const int stream_id, const int substream_id);
 
   // Process Validated Buffer
   void processBuffer(ArvBuffer *p_buffer, size_t stream_id);

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -39,6 +39,7 @@ extern "C" {
 #include <memory>
 #include <atomic>
 #include <thread>
+#include <condition_variable>
 #include <chrono>
 #include <unordered_map>
 
@@ -119,6 +120,10 @@ private:
     std::unique_ptr<ros::NodeHandle> p_camera_info_node_handle;
     sensor_msgs::CameraInfoPtr camera_info;
     ros::Publisher extended_camera_info_pub;
+
+    std::thread buffer_thread;
+    //std::mutex buffer_data_mutex;
+    //std::condition_variable buffer_ready_condition;
   };
 
   // a single stream may transfer multiple substreams (multipart/chunked data)
@@ -178,6 +183,8 @@ protected:
 
   // Buffer Callback Helper
   void newBufferReady(ArvStream *p_stream, size_t stream_id);
+
+  void substreamBufferThreadMain(const int stream, const int substream);
 
   // Process Validated Buffer
   void processBuffer(ArvBuffer *p_buffer, size_t stream_id);

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -122,6 +122,7 @@ private:
     ros::Publisher extended_camera_info_pub;
 
     std::thread buffer_thread;
+    bool buffer_thread_stop;
     //std::mutex buffer_data_mutex;
     //std::condition_variable buffer_ready_condition;
   };
@@ -184,7 +185,7 @@ protected:
   // Buffer Callback Helper
   void newBufferReady(ArvStream *p_stream, size_t stream_id);
 
-  void substreamBufferThreadMain(const int stream, const int substream);
+  void substreamBufferThreadMain(const int stream_id, const int substream_id);
 
   // Process Validated Buffer
   void processBuffer(ArvBuffer *p_buffer, size_t stream_id);

--- a/include/camera_aravis/camera_aravis_nodelet.h
+++ b/include/camera_aravis/camera_aravis_nodelet.h
@@ -197,7 +197,7 @@ protected:
   void processImageBuffer(ArvBuffer *p_buffer, size_t stream_id);
   void processChunkDataBuffer(ArvBuffer *p_buffer, size_t stream_id);
   void processMultipartBuffer(ArvBuffer *p_buffer, size_t stream_id);
-  void processPartBuffer(ArvBuffer *p_buffer, size_t stream_id, size_t substream_id, const void* data, size_t size);
+  void processPartBuffer(ArvBuffer *p_buffer, size_t stream_id, size_t substream_id);
 
   void fillImage(const sensor_msgs::ImagePtr &msg_ptr, ArvBuffer *p_buffer, const std::string frame_id, const Sensor& sensor);
   void fillCameraInfo(Substream &substream, const std_msgs::Header &header);


### PR DESCRIPTION
Implements #11 "thread per substream".

Fixes:
- #10
- as network thread is no longer stopped from working during processing

Each substream has processing thread for:
- GiGE-Vision/GenICam pixel format conversions to ROS
- ROS publishing

Technically:
- aravis buffers are delegated to relevant substream threads for processing.
- multithreading is achieved through signaling threads on new data + mutex guarded shared data
- buffer lifecycle ownership is achieved through shared_ptr
  - in case of multipart substreams all parts share original underlying buffer
  - ownership is passed to processing threads
  - when all threads are done, buffers return to aravis pool


## Breaking Changes

Potentially PTP clock reset
- as it is code running from image/part processing handler and may not be thread safe


