### PR TITLE
rework Photoneo YCoCg(-R) for SIMD autovectorization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,13 @@ project(camera_aravis)
 ## Enable simple buffer processing benchmark output
 #add_compile_definitions(ARAVIS_BUFFER_PROCESSING_BENCHMARK)
 
+## Enable native optimizations & vectorization
+## The generated code may not be portable to different archs
+## Use only when deploying on particular hardware
+#set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -fopt-info-vec-optimized -mavx")
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
+
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   message("${PROJECT_NAME}: You did not request a specific build type: selecting 'Release'.")


### PR DESCRIPTION
Related to #15, #13

Photoneo `YCoCg(-R)` subtly differs from VESA DSC  `YCoCg-R`
- https://github.com/photoneo-3d/photoneo-cpp-examples/issues/4
  - extra check for y==0 zeroying out pixel to protect black pixels in 4:2:0 subsampling
  - potentially small differences in LSbs, some of which are already being corrected
    - when scaling to 8 bit RGB this difference is not visible anyway

- rework our implementation so that it autovectorizes 
- add commented out CMake line to enable autovectoratization
  - do not enable native optimization with vectorization for generic build
    - code generated this way may not be portable to different architectures

------------------------------------

Powersafe
- current implementation is the last column

| No optimization | Optimized | Autovectorized without y==0 check | Autovectorized with y==0 check | Autovectorized with optimized  y==0 check |
|----------------------|------------------|------------------------------------------------|--------------------------------------------|--------------|
| up to 30 ms      |  up to 11 ms|  2-3 ms                                              | Up to 7-8 ms                               |    2-3 ms     |

-----------------------------

Performance
- current implementation is the last column
- for reference, the code would not typically run this way

| No optimization | Optimized | Autovectorized without y==0 check | Autovectorized with y==0 check |  Autovectorized with optimized  y==0 check |
|----------------------|------------------|------------------------------------------------|--------------------------------------------|--------|
| 7 ms      | 3 ms  |  1 ms                                                                           |  2 ms   |  1 ms |

