### PR TITLE
MotionCam3D compatibility with firmware 1.13.3

### DIFF
--- a/calibration/photoneo/motioncam_m_plus/ColorCameraRangeExtrinsics.launch
+++ b/calibration/photoneo/motioncam_m_plus/ColorCameraRangeExtrinsics.launch
@@ -2,15 +2,15 @@
 
 <!--
 # Device: 0
-#  Name:                    MotionCam-3D-TRD-058
-#  Hardware Identification: TRD-058
+#  Name:                    MotionCam-3D-SBT-079
+#  Hardware Identification: SBT-079
 #  Type:                    MotionCam-3D
-#  Firmware version:        1.10.1
+#  Firmware version:        1.13.3
 #  Variant:                 M+
 #  IsFileCamera:            No
 #  Feature-Alpha:           No
 #  Feature-Color:           Yes
-#  Status:                  Not Attached to PhoXi Control. Ready to connect
+#  Status:                  Attached to PhoXi Control. Ready to connect
 
 # Device: 1
 #  Name:                    basic-example
@@ -34,7 +34,7 @@
 #  Feature-Color:           Yes
 #  Status:                  Not Attached to PhoXi Control. Ready to connect
 
-# You have no PhoXi device opened in PhoXi Control, the API Example will try to connect to first device in device list
+# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: SBT-079
 
 # ColorCameraImage (raw RGB, this is not depth aligned RGB texture!)
 # ColorCameraScale: 0.5x0.5
@@ -46,11 +46,11 @@
 # 3D sensor Y axis: [0; 1; 0]
 # 3D sensor Z axis: [0; 0; 1]
 
-# color camera position: [-285.575; 0.348021; -2.64781]
-# color camera X axis: [0.999758; -0.021911; -0.00175325]
-# color camera Y axis: [0.0219171; 0.999753; 0.00358584]
-# color camera Z axis: [0.00167425; -0.0036234; 0.999992]
+# color camera position: [-283.061; -1.00032; -4.84289]
+# color camera X axis: [0.995303; -0.00869798; -0.0964132]
+# color camera Y axis: [0.00895213; 0.999958; 0.0022038]
+# color camera Z axis: [0.0963899; -0.00305655; 0.995339]
 -->
 <launch>
-  <node pkg="tf2_ros" type="static_transform_publisher" name="range_color_camera_link_broadcaster" args="-0.285575 0.000348021 -0.00264781 0.00180242 0.000856928 -0.0109577 0.999938 range_optical_frame color_camera_optical_frame" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="range_color_camera_link_broadcaster" args="-0.283061 -0.00100032 -0.00484289 0.00131664 0.0482575 -0.00441772 0.998824 range_optical_frame color_camera_optical_frame" />
 </launch>

--- a/calibration/photoneo/motioncam_m_plus/ColorCamera_Resolution_1288x730.yaml
+++ b/calibration/photoneo/motioncam_m_plus/ColorCamera_Resolution_1288x730.yaml
@@ -1,8 +1,8 @@
 # Device: 0
-#  Name:                    MotionCam-3D-TRD-058
-#  Hardware Identification: TRD-058
+#  Name:                    MotionCam-3D-SBT-079
+#  Hardware Identification: SBT-079
 #  Type:                    MotionCam-3D
-#  Firmware version:        1.10.1
+#  Firmware version:        1.13.3
 #  Variant:                 M+
 #  IsFileCamera:            No
 #  Feature-Alpha:           No
@@ -31,22 +31,22 @@
 #  Feature-Color:           Yes
 #  Status:                  Not Attached to PhoXi Control. Ready to connect
 
-# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: TRD-058
+# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: SBT-079
 
 # ColorCameraImage (raw RGB, this is not depth aligned RGB texture!)
 # ColorCameraScale: 0.333333x0.333333
 image_width: 1288
 image_height: 730
-camera_name: TRD-058
+camera_name: SBT-079
 camera_matrix: 
   rows: 3
   cols: 3
-  data: [895.519, 0, 636.881, 0, 895.633, 363.132, 0, 0, 1]
+  data: [1035.65, 0, 639.533, 0, 1035.44, 392.875, 0, 0, 1]
 distortion_model: rational_polynomial
 distortion_coefficients: 
   rows: 1
   cols: 8
-  data: [0.0353329, -0.052106, -0.000742206, -0.000100143, 0.006824, 0.0, 0.0, 0.0]
+  data: [-0.356727, 0.209662, 0.000228908, 0.000159935, -0.0926877, 0.0, 0.0, 0.0]
 rectification_matrix: 
   rows: 3
   cols: 3
@@ -54,4 +54,4 @@ rectification_matrix:
 projection_matrix: 
   rows: 3
   cols: 4
-  data: [1158.77, 0, 569.003, 0, 0, 1158.7, 392.4, 0, 0, 0, 1, 0]
+  data: [1154.5, 0, 553.982, 0, 0, 1154.49, 404.14, 0, 0, 0, 1, 0]

--- a/calibration/photoneo/motioncam_m_plus/ColorCamera_Resolution_1932x1096.yaml
+++ b/calibration/photoneo/motioncam_m_plus/ColorCamera_Resolution_1932x1096.yaml
@@ -1,8 +1,8 @@
 # Device: 0
-#  Name:                    MotionCam-3D-TRD-058
-#  Hardware Identification: TRD-058
+#  Name:                    MotionCam-3D-SBT-079
+#  Hardware Identification: SBT-079
 #  Type:                    MotionCam-3D
-#  Firmware version:        1.10.1
+#  Firmware version:        1.13.3
 #  Variant:                 M+
 #  IsFileCamera:            No
 #  Feature-Alpha:           No
@@ -31,22 +31,22 @@
 #  Feature-Color:           Yes
 #  Status:                  Not Attached to PhoXi Control. Ready to connect
 
-# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: TRD-058
+# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: SBT-079
 
 # ColorCameraImage (raw RGB, this is not depth aligned RGB texture!)
 # ColorCameraScale: 0.5x0.5
 image_width: 1932
 image_height: 1096
-camera_name: TRD-058
+camera_name: SBT-079
 camera_matrix: 
   rows: 3
   cols: 3
-  data: [1343.28, 0, 955.571, 0, 1343.45, 544.948, 0, 0, 1]
+  data: [1553.47, 0, 959.55, 0, 1553.15, 589.563, 0, 0, 1]
 distortion_model: rational_polynomial
 distortion_coefficients: 
   rows: 1
-  cols: 8
-  data: [0.0353329, -0.052106, -0.000742206, -0.000100143, 0.006824, 0.0, 0.0, 0.0]
+  cols: 5
+  data: [-0.356727, 0.209662, 0.000228908, 0.000159935, -0.0926877, 0.0, 0.0, 0.0]
 rectification_matrix: 
   rows: 3
   cols: 3
@@ -54,4 +54,4 @@ rectification_matrix:
 projection_matrix: 
   rows: 3
   cols: 4
-  data: [1158.77, 0, 569.003, 0, 0, 1158.7, 392.4, 0, 0, 0, 1, 0]
+  data: [1154.5, 0, 553.982, 0, 0, 1154.49, 404.14, 0, 0, 0, 1, 0]

--- a/calibration/photoneo/motioncam_m_plus/ColorCamera_Resolution_3864x2192.yaml
+++ b/calibration/photoneo/motioncam_m_plus/ColorCamera_Resolution_3864x2192.yaml
@@ -1,13 +1,13 @@
 # Device: 0
-#  Name:                    MotionCam-3D-TRD-058
-#  Hardware Identification: TRD-058
+#  Name:                    MotionCam-3D-SBT-079
+#  Hardware Identification: SBT-079
 #  Type:                    MotionCam-3D
-#  Firmware version:        1.10.1
+#  Firmware version:        1.13.3
 #  Variant:                 M+
 #  IsFileCamera:            No
 #  Feature-Alpha:           No
 #  Feature-Color:           Yes
-#  Status:                  Not Attached to PhoXi Control. Ready to connect
+#  Status:                  Attached to PhoXi Control. Ready to connect
 
 # Device: 1
 #  Name:                    basic-example
@@ -31,22 +31,22 @@
 #  Feature-Color:           Yes
 #  Status:                  Not Attached to PhoXi Control. Ready to connect
 
-# You have no PhoXi device opened in PhoXi Control, the API Example will try to connect to first device in device list
+# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: SBT-079
 
 # ColorCameraImage (raw RGB, this is not depth aligned RGB texture!)
 # ColorCameraScale: 1x1
 image_width: 3864
 image_height: 2192
-camera_name: TRD-058
+camera_name: SBT-079
 camera_matrix: 
   rows: 3
   cols: 3
-  data: [2686.56, 0, 1911.64, 0, 2686.9, 1090.4, 0, 0, 1]
+  data: [3106.94, 0, 1919.6, 0, 3106.31, 1179.63, 0, 0, 1]
 distortion_model: rational_polynomial
 distortion_coefficients: 
   rows: 1
-  cols: 8
-  data: [0.0353329, -0.052106, -0.000742206, -0.000100143, 0.006824, 0.0, 0.0, 0.0]
+  cols: 5
+  data: [-0.356727, 0.209662, 0.000228908, 0.000159935, -0.0926877, 0.0, 0.0, 0.0]
 rectification_matrix: 
   rows: 3
   cols: 3
@@ -54,4 +54,4 @@ rectification_matrix:
 projection_matrix: 
   rows: 3
   cols: 4
-  data: [1158.77, 0, 569.003, 0, 0, 1158.7, 392.4, 0, 0, 0, 1, 0]
+  data: [1154.5, 0, 553.982, 0, 0, 1154.49, 404.14, 0, 0, 0, 1, 0]

--- a/calibration/photoneo/motioncam_m_plus/Range_Camera.yaml
+++ b/calibration/photoneo/motioncam_m_plus/Range_Camera.yaml
@@ -1,8 +1,8 @@
 # Device: 0
-#  Name:                    MotionCam-3D-TRD-058
-#  Hardware Identification: TRD-058
+#  Name:                    MotionCam-3D-SBT-079
+#  Hardware Identification: SBT-079
 #  Type:                    MotionCam-3D
-#  Firmware version:        1.10.1
+#  Firmware version:        1.13.3
 #  Variant:                 M+
 #  IsFileCamera:            No
 #  Feature-Alpha:           No
@@ -31,20 +31,20 @@
 #  Feature-Color:           Yes
 #  Status:                  Not Attached to PhoXi Control. Ready to connect
 
-# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: TRD-058
+# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: SBT-079
 
 image_width: 1120
 image_height: 800
-camera_name: TRD-058
+camera_name: SBT-079
 camera_matrix: 
   rows: 3
   cols: 3
-  data: [1158.77, 0, 569.003, 0, 1158.7, 392.4, 0, 0, 1]
+  data: [1154.5, 0, 553.982, 0, 1154.49, 404.14, 0, 0, 1]
 distortion_model: rational_polynomial
 distortion_coefficients: 
   rows: 1
   cols: 8
-  data: [-0.0810895, 0.105247, 9.91814e-05, 0.00054898, 0.0366575, 0.0, 0.0, 0.0]
+  data: [-0.0927104, 0.176941, 0.000490251, 0.000218982, -0.0903808, 0.0, 0.0, 0.0]
 rectification_matrix: 
   rows: 3
   cols: 3
@@ -52,4 +52,4 @@ rectification_matrix:
 projection_matrix: 
   rows: 3
   cols: 4
-  data: [1158.77, 0, 569.003, 0, 0, 1158.7, 392.4, 0, 0, 0, 1, 0]
+  data: [1154.5, 0, 553.982, 0, 0, 1154.49, 404.14, 0, 0, 0, 1, 0]

--- a/calibration/photoneo/motioncam_m_plus/Range_Scanner.yaml
+++ b/calibration/photoneo/motioncam_m_plus/Range_Scanner.yaml
@@ -1,8 +1,8 @@
 # Device: 0
-#  Name:                    MotionCam-3D-TRD-058
-#  Hardware Identification: TRD-058
+#  Name:                    MotionCam-3D-SBT-079
+#  Hardware Identification: SBT-079
 #  Type:                    MotionCam-3D
-#  Firmware version:        1.10.1
+#  Firmware version:        1.13.3
 #  Variant:                 M+
 #  IsFileCamera:            No
 #  Feature-Alpha:           No
@@ -31,20 +31,20 @@
 #  Feature-Color:           Yes
 #  Status:                  Not Attached to PhoXi Control. Ready to connect
 
-# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: TRD-058
+# You have already PhoXi device opened in PhoXi Control, the API Example is connected to device: SBT-079
 
 image_width: 1680
 image_height: 1200
-camera_name: TRD-058
+camera_name: SBT-079
 camera_matrix: 
   rows: 3
   cols: 3
-  data: [1738.15, 0, 853.754, 0, 1738.04, 589.2, 0, 0, 1]
+  data: [1731.75, 0, 831.222, 0, 1731.74, 606.459, 0, 0, 1]
 distortion_model: rational_polynomial
 distortion_coefficients: 
   rows: 1
   cols: 8
-  data: [-0.0810895, 0.105247, 9.91814e-05, 0.00054898, 0.0366575, 0.0, 0.0, 0.0]
+  data: [-0.0927104, 0.176941, 0.000490251, 0.000218982, -0.0903808, 0.0, 0.0, 0.0]
 rectification_matrix: 
   rows: 3
   cols: 3
@@ -52,4 +52,4 @@ rectification_matrix:
 projection_matrix: 
   rows: 3
   cols: 4
-  data: [1738.15, 0, 853.754, 0, 0, 1738.04, 589.2, 0, 0, 0, 1, 0]
+  data: [1731.75, 0, 831.222, 0, 0, 1731.74, 606.459, 0, 0, 0, 1, 0]

--- a/launch/photoneo_motioncam.launch
+++ b/launch/photoneo_motioncam.launch
@@ -188,7 +188,12 @@
     <param name="frame_id"               value="$(arg frame_id)"/>
     <param name="camera_info_url"        value="$(arg camera_info_url)"/>
 
+
     <!-- use GenICam SFNC names as stream control parameters -->
+
+    <!-- From firmware 1.13.0 SCAN-5003 changed default Scan3dOutputMode to wire inneficient Calibrated_ABC_Grid.  -->
+    <!-- We need the wire-efficient ProjectedC with pixel format Coord3D_C32f to get 10 FPS with RGB and Depth  -->
+    <param name="Scan3dOutputMode"         value="ProjectedC"/>
 
     <!-- MTU maps to GenICam GevSCPSPacketSize or DeviceStreamChannelPacketSize -->
     <param name="GevSCPSPacketSize"      value="$(arg mtu)" type="int" unless="$(eval mtu == 0)" />

--- a/src/camera_aravis_nodelet.cpp
+++ b/src/camera_aravis_nodelet.cpp
@@ -453,12 +453,15 @@ void CameraAravisNodelet::onInit()
   }
 
   disableComponents();
-  initPixelFormats();
 
-  // set automatic rosparam features before bounds checking
-  // as some settings have side effects on sensor size/ROI
+  // set automatic rosparam features before
+  // bounds checking and pixel formats setup
+  // as some settings have side effects on
+  // sensor size/ROI and available pixel formats
   // we will also set them second time (!)
   writeCameraFeaturesFromRosparamForStreams();
+
+  initPixelFormats();
 
   getBounds();
 


### PR DESCRIPTION
Adapt to SCAN-5003 breaking firmware change
- this changes default pixel format for Range data

We:
- set `Scan3DOutputMode` to `ProjectedC`
- this lets us select again `Coord3D_C32f` pixel format

We also need to set generic GenICam features before pixel format setup
- `Coord3D_C32f` pixel format is not available until we set `Scan3DOutputMode` to `ProjectedC`

Finally calibration for MotionCam-3D-SBT-079 was extracted and set as default
